### PR TITLE
Fix typos in Readme; add info about YAML to Readme and example-vars.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ You will need to install the following additional Ansible modules before running
 ##4. A vars.yml File that has Values Set for Your Specific OFN Installation
 The playbooks use values set in the `vars.yml` file to accomplish their tasks. Information includes such things as the specific domain name for your OFN system, the password to the database used by OFN, file names, paths, etc.  This repository does *not* have a `vars.yml` file by default:  You must copy the `example-vars.yml` file to create your own `vars.yml` file.  (Ex: `cp example-vars.yml vars.yml`)  Then you must edit the `vars.yml` file and put in the values that are appropriate for your system and set-up.  Note that you may need to edit your `vars.yml` file before running a playbook; you may want to change the `rails_env` from `testing` to `staging` for example.  In other words, you don't just create and edit the `vars.yml` file once and forget about it.
 
+If you're not familiar with YAML, read more at [the official YAML site.](http://www.yaml.org/)  
+
+You can validate the syntax of your vars.yml file with the [Online YAML Parser.](http://yaml-online-parser.appspot.com)
    
 
 

--- a/example-vars.yml
+++ b/example-vars.yml
@@ -2,6 +2,17 @@
 # Variables to get your Open Food Network instance running
 # 
 # Copy this file to vars.yml before filling out!
+#
+# This is a YAML file. Read more about YAML syntax at the official YAML site:
+#  http://www.yaml.org
+#
+#  Note that YAML expects a space after the colon that follows a key (variable) name.
+#  For example, given the key "user", and the value "ubuntu" YAML expects the line
+#  to be written like this:
+#    user: ubuntu   # note the space after the colon
+#
+# You can validate the syntax of your vars.yml file with the Online YAML Parser:
+#  http://yaml-online-parser.appspot.com
 #----------------------------------------------------------------------
 
 


### PR DESCRIPTION
Fix some typos in the Readme and add information about YAML.  Info about YAML added to the header comment of the example-vars.yml file to help those unfamiliar with YAML syntax. (see issue #7  - install.yml errors)
