### PR TITLE
no interactive prompt during language pack install

### DIFF
--- a/roles/language/tasks/main.yml
+++ b/roles/language/tasks/main.yml
@@ -11,5 +11,5 @@
   become: yes
 
 - name: reconfigure locales
-  shell: "dpkg-reconfigure locales"
+  shell: "dpkg-reconfigure -f noninteractive locales"
   become: yes


### PR DESCRIPTION
running the playbooks in latest ubuntu container
during installing ubuntu german language packs
ansible prompts interactive input for locale

This is also happens during manual install
Might be due to ubuntu version difference?
