### PR TITLE
Skip default user role if it already exists

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -2,12 +2,17 @@
 - name: default_user
   hosts: ofn_servers
   remote_user: root
+  gather_facts: no
+  pre_tasks:
+    - name: Check if default user exists, we will skip the default_user role if already existent.
+      local_action: "command ssh -q -o BatchMode=yes -o ConnectTimeout=3 {{ user }}@{{ inventory_hostname }} 'echo ok'"
+      register: check_default_user
+      ignore_errors: true
   roles:
     - role: default_user
       become: yes
       tags: default_user
-
-
+      when: "'ok' != check_default_user.stdout"
 
 - name: provision
   hosts: ofn_servers


### PR DESCRIPTION
The first time we execute `playbook/provisioning.yml` it does the following things with the `default_user` role:

- connect via SSH with `root` user
- create the default user `ofn-admin`
- copy the ssh key

After that we execute the role `geerlingguy.security` which changes the `/etc/ssh/sshd_config` file to deny access with `root` user.

At this point we cannot run the `playbook/provisioning.yml` playbook again since the `default_user` role would fail trying to access the host with the `root` user.

Until now we're just commenting out the `default_user` role but it's not a comfortable solution.

With this PR we propose to execute a `pre_task` to check if the `ofn-admin`user has been created and if that's the case we can skip the `default_user` role at once.

