### PR TITLE
Compile bugsnag's initializer template

### DIFF
--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -42,6 +42,17 @@
     - { src: "seed.sh.j2", dest: "{{ config_path }}/seed.sh" }
   tags: app_templates
 
+- name: copy the bugsnag's initializer file into the shared folder
+  template:
+    src: "bugsnag.rb.j2"
+    dest: "{{ config_path }}/bugsnag.rb"
+    owner: "{{ unicorn_user }}"
+    mode: 0775
+  tags:
+    - app_templates
+    - bugsnag
+  when: bugsnag_key != "none"
+
 - name: copy the db2fog file into the shared folder
   template:
     src: db2fog.rb.j2

--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -42,6 +42,8 @@
     - { src: "seed.sh.j2", dest: "{{ config_path }}/seed.sh" }
   tags: app_templates
 
+# Note this requires the `bugsnag_key` var to be specified otherwise no
+# template will be copied
 - name: copy the bugsnag's initializer file into the shared folder
   template:
     src: "bugsnag.rb.j2"


### PR DESCRIPTION
## What?

Although in https://github.com/openfoodfoundation/ofn-install/blob/master/roles/deploy/tasks/main.yml#L60 we have a step that symlinks the bugsnag config/initializer from the `config_path` to the app's config folder, there was no step at provisioning time that copied the template to `config_path`.

I do it this way because this is the pattern I see in `ofn-install` but it'd be much simpler to have the `config/initializer/bugsnag.rb` in OFN's repo and read the api key from an env var like any other regular Rails app. No need for any extra steps at provisioning and deploy time then.