### PR TITLE
Include /etc/nginx/sites-available/ofn/* in nginx

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -169,6 +169,8 @@ nginx_sites:
       client_max_body_size 4G;
       keepalive_timeout 60;
 
+      include /etc/nginx/sites-available/ofn/*;
+
 nginx_events_params:
   - worker_connections 768
 


### PR DESCRIPTION
This allows adding custom per-instance locations to the nginx config. Useful to try out ideas before merging them into OFN.