### PR TITLE
Add maps api key to secrets.yml

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -14,6 +14,10 @@ admin_password:
 # Generate one with a bash command like: openssl rand -hex 128
 secret_token: 'xxxxxx'
 
+# New app deployments will need a Google Maps API key to correctly display 
+# the OFN Map
+google_maps_api_key:
+
 
 # Set this if using New Relic
 newrelic_license_key:


### PR DESCRIPTION
**What** **Why**
On running the OFN-install scripts OFN requires a Google Maps API key to correctly configure.

There is no other mention in the Wiki so this seems like the most appropriate place to ensure the user knows to include.