### PR TITLE
enable HTTP/2 in nginx config

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -131,8 +131,8 @@ nginx_sites:
 
   ofn_443:
     - |
-      listen 443 ssl;
-      listen [::]:443 ssl;
+      listen 443 ssl http2;
+      listen [::]:443 ssl http2;
       server_name {{ domain }};
       root {{ app_root }}/public;
 


### PR DESCRIPTION
This small change enables HTTP/2

If someone deploys on Debian, you might want to check if it still has issue with OpenSSL version https://sergii.rocks/feed/post/nginx-http2-with-alpn-on-debian-8-jessie

I deploy to Ubuntu 16.04 LTS running in [LXD](https://linuxcontainers.org/lxd/) container and it works just fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openfoodfoundation/ofn-install/110)
<!-- Reviewable:end -->
