### PR TITLE
update geerlingguy.certbot to 3.0.0 and also use it to generate cert …

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -10,4 +10,4 @@
   version: v2.7.4
 
 - src: geerlingguy.certbot
-  version: 1.0.1
+  version: 3.0.0

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -48,12 +48,16 @@
       db_user_roles: CREATEDB
 
     - role: geerlingguy.certbot
-      become: yes
+      certbot_install_from_source: yes
       certbot_auto_renew_user: "{{ unicorn_user }}"
-      when: protocol == "https"
-      tags: cert
-
-    - role: cert
+      certbot_create_if_missing: yes
+      certbot_create_method: standalone
+      certbot_create_standalone_stop_services: []
+      certbot_admin_email: "{{ developer_email }}"
+      certbot_certs:
+        - domains:
+          - "{{ domain }}"
+      become: yes
       when: protocol == "https"
       tags: cert
 

--- a/roles/cert/tasks/main.yml
+++ b/roles/cert/tasks/main.yml
@@ -1,5 +1,0 @@
----
-
-- name: Create certificates using certbot
-  command: "/opt/certbot/certbot-auto certonly --standalone --agree-tos --email {{ developer_email }} --noninteractive -d {{ domain }}"
-  tags: skip_ansible_lint


### PR DESCRIPTION
…with standalone

Before merging it we may want to make sure #105 gets resolved so we can properly test the whole playbook. This version fails in exactly the same way as the old one and works if `--webroot -w` + `python -m SimpleHTTPServer 80` used instead of `--standalone`, just as the old version do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openfoodfoundation/ofn-install/117)
<!-- Reviewable:end -->
