### PR TITLE
Use coopdevs role to install certbot and nginx plugin

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -1,4 +1,3 @@
-
 # from galaxy
 - src: geerlingguy.security
   version: 1.5.0
@@ -9,5 +8,5 @@
 - src: jdauphant.nginx
   version: v2.7.4
 
-- src: geerlingguy.certbot
-  version: 1.0.1
+- src: coopdevs.certbot_nginx
+  version: 0.0.1

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -12,8 +12,6 @@ user: ofn-admin
 # to connect using SSH instead of just passwords.
 ssh_pubkey: "{{ lookup('file', '~/.ssh/{{ ssh_pubkey_name }}') }}"
 
-protocol: https
-
 git_repo: https://github.com/openfoodfoundation/openfoodnetwork.git
 git_version:  v1.8.6
 

--- a/inventory/host_vars/local_vagrant/config.yml
+++ b/inventory/host_vars/local_vagrant/config.yml
@@ -4,5 +4,3 @@ domain: localhost
 rails_env: test
 
 admin_email: admin@example.com
-
-protocol: http

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -47,15 +47,11 @@
       tags: dbserver
       db_user_roles: CREATEDB
 
-    - role: geerlingguy.certbot
+    - role: coopdevs.certbot_nginx
       become: yes
-      certbot_auto_renew_user: "{{ unicorn_user }}"
-      when: protocol == "https"
-      tags: cert
-
-    - role: cert
-      when: protocol == "https"
-      tags: cert
+      vars:
+        domain_name: "{{ domain }}"
+        letsencrypt_email: "{{ developer_email }}"
 
     - role: jdauphant.nginx
       become: yes

--- a/roles/cert/tasks/main.yml
+++ b/roles/cert/tasks/main.yml
@@ -1,5 +1,0 @@
----
-
-- name: Create certificates using certbot
-  command: "/opt/certbot/certbot-auto certonly --standalone --agree-tos --email {{ developer_email }} --noninteractive -d {{ domain }}"
-  tags: skip_ansible_lint


### PR DESCRIPTION
### WAT
So, it seems that in the role that we're using now there is no support for the nginx plugin for renewal https://github.com/geerlingguy/ansible-role-certbot/issues/2#issuecomment-365369540

Since this is something that we need to address ASAP we created an [Ansible role](https://github.com/coopdevs/certbot_nginx) to just:
1. Install `certbot` and `nginx` plugin
2. Generate the certificate if needed

We also remove our `cert` role since it's just creating confusion. It was generating the certificate, let's do that in the external role (same strategy as geerling's role)

Solves https://github.com/openfoodfoundation/ofn-install/issues/86
Solves https://github.com/openfoodfoundation/ofn-install/issues/105
Supersedes https://github.com/openfoodfoundation/ofn-install/pull/117