### PR TITLE
Provide SKYLIGHT_AUTHENTICATION to unicorn user

### DIFF
--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -4,3 +4,5 @@ domain: example.com
 rails_env: production
 
 admin_email: admin@example.com
+
+skylight_authentication: xxx

--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -4,5 +4,3 @@ domain: example.com
 rails_env: production
 
 admin_email: admin@example.com
-
-skylight_authentication: xxx

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -20,3 +20,6 @@ google_maps_api_key:
 
 # Set this if using New Relic
 newrelic_license_key:
+
+# Skylight's API key. This enables performance instrumentation through Skylight. See https://github.com/openfoodfoundation/openfoodnetwork/pull/2070 for details.
+skylight_authentication: xxx

--- a/roles/unicorn_user/templates/defaults.j2
+++ b/roles/unicorn_user/templates/defaults.j2
@@ -1,2 +1,5 @@
 RAILS_ENV={{ rails_env }}
-SKYLIGHT_AUTHENTICATION={{ skylight_authentication }}
+
+{% if skylight_authentication is defined %}
+  SKYLIGHT_AUTHENTICATION={{ skylight_authentication }}
+{% endif %}

--- a/roles/unicorn_user/templates/defaults.j2
+++ b/roles/unicorn_user/templates/defaults.j2
@@ -1,1 +1,2 @@
 RAILS_ENV={{ rails_env }}
+SKYLIGHT_AUTHENTICATION={{ skylight_authentication }}


### PR DESCRIPTION
## What?

Closes #120 

As described in https://www.skylight.io/support/advanced-setup#enabling-additional-environments, by setting `SKYLIGHT_AUTHENTICATION`, we'll enable skylight to gather instrumentation data in production. 

`skylight_authentication` has been set as secret already in https://github.com/coopdevs/katuma_secrets/pull/1 and https://github.com/coopdevs/katuma_secrets/pull/2 for Katuma.

Once we get this working other instances can set their own. 