### PR TITLE
Restart delayed job after running db:seed

### DIFF
--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -14,7 +14,7 @@
 
 
 - name: restart delayed job workers
-  command:  bash -lc "./script/delayed_job -i 0 stop RAILS_ENV={{ rails_env }}" chdir="{{ current_path }}"
+  command:  bash -lc "./script/delayed_job -i 0 restart RAILS_ENV={{ rails_env }}" chdir="{{ current_path }}"
 
 
 - name: restart unicorn

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -14,8 +14,7 @@
 
 
 - name: restart delayed job workers
-  command:  bash -lc "./script/delayed_job -i 0 restart RAILS_ENV={{ rails_env }}" chdir="{{ current_path }}"
-
+  command:  bash -lc "./script/delayed_job restart --pid-dir={{ pid_path }} RAILS_ENV={{ rails_env }}" chdir="{{ current_path }}"
 
 - name: restart unicorn
   command: psql -h {{ db_host }} -U {{ db_user }} -d {{ db }} -c "SELECT true FROM pg_tables WHERE tablename = 'order_cycles';"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -209,3 +209,4 @@
     - skip_ansible_lint
   notify:
     - restart unicorn
+    - restart delayed job workers


### PR DESCRIPTION
This ensures new Spree configuration values will be picked up. In any case, it's safer to restart the services at the end of the deployment so we don't miss any configuration or code to be reloaded.

Apart from that, it's simpler to make it restart rather stopping and relying on monit to bring it up.