### PR TITLE
Add ssh config for vagrant

### DIFF
--- a/inventory/dev
+++ b/inventory/dev
@@ -1,6 +1,6 @@
 
 [vagrant]
-local_vagrant ansible_host=192.168.50.4
+local_vagrant ansible_host=127.0.0.1 ansible_user=vagrant ansible_port=2222 ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 
 [lxc]
 local.ofn.org


### PR DESCRIPTION
Instead of relying on a magic IP address, I found this configuration to connect to a local vagrant machine without prior knowledge. Let me know if you know a better way or this doesn't work for you.