### PR TITLE
Run certbot as root

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -49,7 +49,6 @@
 
     - role: geerlingguy.certbot
       become: yes
-      certbot_auto_renew_user: "{{ unicorn_user }}"
       when: protocol == "https"
       tags: cert
 


### PR DESCRIPTION
Running it as the openfoodnetwork user fails since it doesn't have sudo
permissions.

Fixes https://github.com/openfoodfoundation/ofn-install/issues/86

This would become obsolete with #124, but is a smaller change and could be merged before.