### PR TITLE
Gitignore vendor/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ community
 inventory/host_vars/*/secrets.yml
 *.log
 **/*.retry
+vendor/


### PR DESCRIPTION
## What?

`vendor/` seems to be Ansible's default location for plugins. As this wasn't ignored by git, it always shows up as untracked files when I run `git status` and it's quite annoying. I'm just ignoring it now.