### PR TITLE
Specify SKYLIGHT_AUTHENTICATION in systemd unit

### DIFF
--- a/roles/webserver/templates/unicorn.service.j2
+++ b/roles/webserver/templates/unicorn.service.j2
@@ -8,6 +8,11 @@ Type=simple
 User=openfoodnetwork
 WorkingDirectory={{ current_path }}
 Environment=RAILS_ENV={{ rails_env }}
+
+{% if skylight_authentication is defined %}
+  Environment=SKYLIGHT_AUTHENTICATION={{ skylight_authentication }}
+{% endif %}
+
 SyslogIdentifier=openfoodnetwork-unicorn
 PIDFile={{ unicorn_pid }}
 


### PR DESCRIPTION
Otherwise, Unicorn cannot see this env var and Skylight reports a "authentication token required".