### PR TITLE
Add missing Stripe keys in application.yml template

### DIFF
--- a/roles/app/defaults/main.yml
+++ b/roles/app/defaults/main.yml
@@ -5,3 +5,5 @@ s3_secret: none
 
 stripe_client_id: none
 stripe_instance_secret_key: none
+stripe_instance_publishable_key: none
+stripe_endpoint_secret: none

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -23,3 +23,5 @@ S3_SECRET: {{ s3_secret }}
 
 STRIPE_CLIENT_ID: {{ stripe_client_id }}
 STRIPE_INSTANCE_SECRET_KEY: {{ stripe_instance_secret_key }}
+STRIPE_INSTANCE_PUBLISHABLE_KEY: {{ stripe_instance_publishable_key }}
+STRIPE_ENDPOINT_SECRET: {{ stripe_endpoint_secret }}


### PR DESCRIPTION
Following the doc https://github.com/openfoodfoundation/openfoodnetwork/wiki/Setting-up-Stripe-on-an-OFN-instance, we were missing 2 variables on Ansible side to provide the specified way to enable Stripe into the OFN instance.