### PR TITLE
Missing environment variables for Stripe and S3

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -17,7 +17,7 @@ secret_token: 'xxxxxx'
 # Create a Google Maps API key and enable Javascript and Places libraries
 google_maps_api_key:
 
-# Amazon S3 backups with db2fog
+# Set these if using Amazon S3 backups with db2fog
 s3_backups_bucket:
 s3_access_key:
 s3_secret:

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -17,6 +17,20 @@ secret_token: 'xxxxxx'
 # Create a Google Maps API key and enable Javascript and Places libraries
 google_maps_api_key:
 
+# Amazon S3 backups with db2fog
+s3_backups_bucket:
+s3_access_key:
+s3_secret:
+
+# Stripe Connect API keys
+# Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings
+# Under 'Connect', the Redirect URI should be set to https://YOUR_SERVER_URL/stripe/callbacks (e.g. https://openfoodnetwork.org.uk/stripe/callbacks)
+# Under 'Webhooks', you should set up a Connect endpoint pointing to https://YOUR_SERVER_URL/stripe/webhooks e.g. (https://openfoodnetwork.org.uk/stripe/webhooks)
+# Different keys can be made for testing or live environments
+stripe_client_id: # ca_xxxx
+stripe_instance_secret_key: # sk_xxxx
+stripe_instance_publishable_key: # pk_xxxx
+stripe_endpoint_secret: # whsec_xxxx
 
 # Set this if using New Relic
 newrelic_license_key:

--- a/roles/app/defaults/main.yml
+++ b/roles/app/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
-s3_backups_bucket: none
-s3_access_key: none
-s3_secret: none
+s3_backups_bucket:
+s3_access_key:
+s3_secret:
 
-stripe_client_id: none
-stripe_instance_secret_key: none
+stripe_client_id:
+stripe_instance_secret_key:
+stripe_instance_publishable_key:
+stripe_endpoint_secret:

--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -57,7 +57,7 @@
   tags:
     - app_templates
     - db2fog
-  when: s3_backups_bucket != "none"
+  when: s3_backups_bucket != ""
 
 - name: get l10n repo
   git:

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -18,8 +18,11 @@ CHECKOUT_ZONE: {{ checkout_zone }}
 
 GOOGLE_MAPS_API_KEY: {{ google_maps_api_key }}
 
+S3_BACKUPS_BUCKET: {{ s3_backups_bucket }}
 S3_ACCESS_KEY: {{ s3_access_key }}
 S3_SECRET: {{ s3_secret }}
 
 STRIPE_CLIENT_ID: {{ stripe_client_id }}
 STRIPE_INSTANCE_SECRET_KEY: {{ stripe_instance_secret_key }}
+STRIPE_INSTANCE_PUBLISHABLE_KEY: {{ stripe_instance_publishable_key }}
+STRIPE_ENDPOINT_SECRET: {{ stripe_endpoint_secret }}

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -6,4 +6,4 @@ newrelic_license_key: none
 
 bugsnag_key: none
 
-s3_backups_bucket: none
+s3_backups_bucket:

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -75,7 +75,7 @@
     force=yes
     owner={{ unicorn_user }}
     mode=0775
-  when: s3_backups_bucket != "none"
+  when: s3_backups_bucket != ""
   tags: symlink
 
 - name: symlink the newrelic file into the config folder


### PR DESCRIPTION
Closes #170.

Making sure we actually provision the env vars we need, and updating the example `secrets.yml` file to make it clearer what should be in there.