### PR TITLE
Delayed job systemd unit

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,0 +1,13 @@
+- name: stop monit service
+  service:
+    name: monit
+    state: stopped
+  become: yes
+  become_user: root
+
+- name: remove monit package
+  apt:
+    pkg: monit
+    state: absent
+  become: yes
+  become_user: root

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -33,13 +33,18 @@
     - libxslt1-dev
     - memcached
     - ranger
-    - monit
     #- fontconfig # needed for phantomjs
     #- nfs-common # make virtualbox faster
   tags: packages
 
-- name: configure monit
-  template:
-    src=monit.j2
-    dest=/etc/monit/conf.d/{{ app }}
+# Remove monit if still installed. The notified handlers will run only once
+# (when the main task triggers a change by removing the config file)
+- name: clean up monit
+  file:
+    state: absent
+    path: /etc/monit/conf.d/{{ app }}
   become: yes
+  become_user: root
+  notify:
+    - stop monit service
+    - remove monit package

--- a/roles/common/templates/monit.j2
+++ b/roles/common/templates/monit.j2
@@ -1,9 +1,0 @@
-check process openfoodnetwork_dj_worker_0
-  with pidfile {{ current_path }}/tmp/pids/delayed_job.0.pid
-  start program = "/bin/bash -c 'RAILS_ENV={{ rails_env }} {{ unicorn_home_path }}/.rbenv/shims/ruby {{ current_path }}/script/delayed_job -i 0 start'"
-  as uid {{ unicorn_user }} and gid {{ unicorn_user }}
-  with timeout 120 seconds
-  stop program = "/bin/bash -c 'RAILS_ENV={{ rails_env }} {{ unicorn_home_path }}/.rbenv/shims/ruby {{ current_path }}/script/delayed_job -i 0 stop'"
-  as uid {{ unicorn_user }} and gid {{ unicorn_user }}
-  with timeout 120 seconds
-  if mem is greater than 250.0 MB for 3 cycles then restart

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -11,10 +11,12 @@
 - name: precompile nondigest assets
   command: bash -lc "bundle exec rake assets:precompile:nondigest RAILS_GROUPS=assets RAILS_ENV={{ rails_env }}" chdir="{{ current_path }}"
 
-
-
-- name: restart delayed job workers
-  command:  bash -lc "./script/delayed_job restart --pid-dir={{ pid_path }} RAILS_ENV={{ rails_env }}" chdir="{{ current_path }}"
+- name: restart delayed job service
+  service:
+    name: delayed_job_{{ app }}
+    state: restarted
+  become: yes
+  become_user: root
 
 - name: restart unicorn
   command: psql -h {{ db_host }} -U {{ db_user }} -d {{ db }} -c "SELECT true FROM pg_tables WHERE tablename = 'order_cycles';"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -184,7 +184,7 @@
   notify:
     - precompile assets
     - restart unicorn
-    - restart delayed job workers
+    - restart delayed job service
 
 - name: seed database
   # We run a shell script that passes the default email and password to rake with an EOF block, so we don't hang on the prompts.
@@ -208,5 +208,5 @@
     - skip_ansible_lint
   notify:
     - restart unicorn
-    - restart delayed job workers
+    - restart delayed job service
     - update whenever

--- a/roles/webserver/defaults/main.yml
+++ b/roles/webserver/defaults/main.yml
@@ -14,3 +14,6 @@ unicorn_pid: "{{ pid_path }}/unicorn.pid"
 unicorn_sock: "{{ sock_path }}/unicorn.{{ app }}.sock"
 unicorn_workers: 2
 unicorn_timeout: 30
+
+# Delayed_job
+delayed_job_pid: "{{ pid_path }}/delayed_job.pid"

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -1,6 +1,6 @@
 --- # webserver
 
-- name: copy unicorn files
+- name: copy init scripts files
   template:
     src={{ item.src }}
     dest={{ item.dest }}
@@ -12,13 +12,20 @@
     - { src: "unicorn_init.j2", dest: "/etc/init.d/unicorn_{{ app }}", mode: "0744", owner: "{{ unicorn_user }}", group: "{{ unicorn_user }}" }
     - { src: "unicorn.rb.j2", dest: "{{ config_path }}/unicorn.rb", mode: "0744", owner: "{{ unicorn_user }}", group: "{{ unicorn_user }}" }
     - { src: "unicorn.service.j2", dest: "/etc/systemd/system/unicorn_{{ app }}.service", mode: "0744", owner: "{{ unicorn_user }}", group: "{{ unicorn_user }}" }
+    - { src: "delayed_job.service.j2", dest: "/etc/systemd/system/delayed_job_{{ app }}.service", mode: "0744", owner: "{{ unicorn_user }}", group: "{{ unicorn_user }}" }
   notify:
     - restart nginx
-  tags: unicorn
+  tags: init
 
-- name: update unicorn
+- name: Enable unicorn unit
   service:
     name: "unicorn_{{ app }}"
     enabled: yes
   become: yes
-  tags: unicorn
+  tags: init
+
+- name: Enable delayed_job unit
+  service:
+    name: "delayed_job_{{ app }}"
+    enabled: yes
+  tags: init

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -24,6 +24,13 @@
   become: yes
   tags: init
 
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes
+  become: yes
+  become_user: root
+  tags: init
+
 - name: Enable delayed_job unit
   service:
     name: "delayed_job_{{ app }}"

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -28,4 +28,5 @@
   service:
     name: "delayed_job_{{ app }}"
     enabled: yes
+  become: yes
   tags: init

--- a/roles/webserver/templates/delayed_job.service.j2
+++ b/roles/webserver/templates/delayed_job.service.j2
@@ -4,14 +4,15 @@
 Description=Open Food Network delayed_job
 
 [Service]
-Type=simple
-User=openfoodnetwork
-WorkingDirectory={{ current_path }}
-Environment=RAILS_ENV={{ rails_env }}
-SyslogIdentifier=openfoodnetwork-delayed_job
+Type=forking
 PIDFile={{ delayed_job_pid }}
-
-ExecStart=script/delayed_job
+RemainAfterExit=no
+Restart=on-failure
+RestartSec=60s
+User=openfoodnetwork
+SyslogIdentifier=openfoodnetwork-delayed_job
+ExecStart=/bin/bash -c "RAILS_ENV={{ rails_env }} {{ unicorn_home_path }}/.rbenv/shims/ruby {{ current_path }}/script/delayed_job start --pid-dir={{ pid_path }}"
+ExecStop=/bin/bash -c "RAILS_ENV={{ rails_env }} {{ unicorn_home_path }}/.rbenv/shims/ruby {{ current_path }}/script/delayed_job stop --pid-dir={{ pid_path }}"
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/webserver/templates/delayed_job.service.j2
+++ b/roles/webserver/templates/delayed_job.service.j2
@@ -1,0 +1,17 @@
+# Open Food Network delayed_job systemd service
+
+[Unit]
+Description=Open Food Network delayed_job
+
+[Service]
+Type=simple
+User=openfoodnetwork
+WorkingDirectory={{ current_path }}
+Environment=RAILS_ENV={{ rails_env }}
+SyslogIdentifier=openfoodnetwork-delayed_job
+PIDFile={{ delayed_job_pid }}
+
+ExecStart=script/delayed_job
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #84 and #179. And probably #119.

This PR adds a new systemd unit for managing our delayed_job processes. It also removes the monit package which is now no longer needed, as systemd is now configured to restart the service when it is not running.

It is usable as a regular service e.g: `sudo systemctl restart delayed_job_openfoodnetwork.service`. The tasks that start/reload delayed_job have been switched to use this service instead of the directly running the script. 

![screenshot from 2018-07-13 21-42-22](https://user-images.githubusercontent.com/9029026/42726207-57ed1c72-8788-11e8-9303-ee9abb3f8207.png)

I've also added a new task to run `systemctl daemon-reload` to reload the config after any systemd files have been updated, because they won't work otherwise.