### PR TITLE
Remove outdated credits section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,3 @@ ansible-lint site.yml --exclude=community
 This is also run by Travis.
 
 ---
-
-
-
-## Credits
-
-* Rafael Schouten (https://github.com/rafaqz)
-* Paul Mackay (https://github.com/pmackay)
-* Ashley Englund (https://github.com/weedySeaDragon)
-* Rohan Mitchell (http://github.com/rohanm)
-* Maikel Linke (https://github.com/mkllnk)


### PR DESCRIPTION
It is a chore to keep the credits section up to date when many people
are contributing. In times of Git and Github, we don't need to bother
about manually updating an author list, because it can be generated
automatically.