### PR TITLE
Trigger language rebuilding only when changed

### DIFF
--- a/roles/language/handlers/main.yml
+++ b/roles/language/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: update locales
+  command: "update-locale LANG={{ language }} LC_ALL={{ language }} LC_CTYPE={{ language }}"
+  become: yes
+  notify: reconfigure locales
+
+- name: reconfigure locales
+  command: "dpkg-reconfigure -f noninteractive locales"
+  become: yes

--- a/roles/language/tasks/main.yml
+++ b/roles/language/tasks/main.yml
@@ -5,13 +5,5 @@
     pkg: "{{ item }}"
     state: present
   with_items: "{{ language_packages }}"
-
-- name: update locales
-  command: "update-locale LANG={{ language }} LC_ALL={{ language }} LC_CTYPE={{ language }}"
-  become: yes
-  tags: skip_ansible_lint
-
-- name: reconfigure locales
-  command: "dpkg-reconfigure -f noninteractive locales"
-  become: yes
-  tags: skip_ansible_lint
+  notify:
+    - update locales


### PR DESCRIPTION
Moving the rebuild tasks into triggers means that they don't run unless
the language packages changed.