### PR TITLE
More efficient bundler install

### DIFF
--- a/roles/bundler/tasks/main.yml
+++ b/roles/bundler/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: install bundler
   # This needs to be run inside a bash shell to initialise rbenv
   # See http://stackoverflow.com/questions/22115936/install-bundler-gem-using-ansible
-  command: bash -lc "gem install bundler  --no-ri --no-rdoc"
+  command: bash -lc "RBENV_VERSION='{{ ruby_version }}' gem install bundler --no-ri --no-rdoc"
   tags: skip_ansible_lint
 
 - name: reload rbenv

--- a/roles/bundler/tasks/main.yml
+++ b/roles/bundler/tasks/main.yml
@@ -6,7 +6,3 @@
   command: bash -lc "RBENV_VERSION='{{ ruby_version }}' gem install bundler --no-ri --no-rdoc"
   args:
     creates: "~/.rbenv/shims/bundler"
-
-- name: reload rbenv
-  command: bash -lc "rbenv rehash"
-  tags: skip_ansible_lint

--- a/roles/bundler/tasks/main.yml
+++ b/roles/bundler/tasks/main.yml
@@ -4,7 +4,8 @@
   # This needs to be run inside a bash shell to initialise rbenv
   # See http://stackoverflow.com/questions/22115936/install-bundler-gem-using-ansible
   command: bash -lc "RBENV_VERSION='{{ ruby_version }}' gem install bundler --no-ri --no-rdoc"
-  tags: skip_ansible_lint
+  args:
+    creates: "~/.rbenv/shims/bundler"
 
 - name: reload rbenv
   command: bash -lc "rbenv rehash"


### PR DESCRIPTION
The bundler install was always run, even if already present. This adds a check for it's success, removes an unnecessary step and makes sure that we install bundler for the right ruby version.