### PR TITLE
Specify the Rails env when updating cron jobs

### DIFF
--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -52,6 +52,6 @@
   become_user: root
 
 - name: update whenever
-  command: bash -lc "bundle exec whenever --update-crontab RAILS_ENV={{ rails_env }}"
+  command: bash -lc "bundle exec whenever --set 'environment={{ rails_env }}' --update-crontab"
   args:
     chdir: "{{ current_path }}"


### PR DESCRIPTION
Although we were passing RAILS_ENV when updating cron jobs through
`whenever --update-crontab`, it turns out that `production` is the
default value for the `:environment` argument.

I spotted this while investigating why we had 9 failed `db2fog:backup`
cron jobs reported in Bugsnag for production. That was impossible as we
didn't provision production in a very long time although we did in
staging.

The problem was that `crontab -l` in staging returned something like:

```
0 * * * * /bin/bash -l -c 'cd /home/openfoodnetwork/apps/openfoodnetwork/current && RAILS_ENV=production bundle exec rake openfoodnetwork:cache:check_products_integrity --silent'
```

Thus, these jobs were executed as if they were in production.