### PR TITLE
Add mail method settings

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -43,3 +43,7 @@ mail_host:
 mail_port:
 smtp_username:
 smtp_password:
+
+# Optional mail settings
+# mails_from: from_address@example.com
+# mail_bcc: bcc_me@example.com

--- a/roles/unicorn_user/templates/defaults.j2
+++ b/roles/unicorn_user/templates/defaults.j2
@@ -9,5 +9,9 @@ MAIL_HOST={{ mail_host }}
 MAIL_PORT={{ mail_port }}
 SMTP_USERNAME={{ smtp_username }}
 SMTP_PASSWORD={{ smtp_password }}
-MAILS_FROM={{ mails_from | default("no-reply@{{ mail_domain }}") }}
-MAIL_BCC={{ mail_bcc | default('') }}
+{% if mails_from is defined %}
+  MAILS_FROM={{ mails_from }}
+{% endif %}
+{% if mail_bcc is defined %}
+  MAIL_BCC={{ mail_bcc }}
+{% endif %}

--- a/roles/unicorn_user/templates/defaults.j2
+++ b/roles/unicorn_user/templates/defaults.j2
@@ -9,3 +9,5 @@ MAIL_HOST={{ mail_host }}
 MAIL_PORT={{ mail_port }}
 SMTP_USERNAME={{ smtp_username }}
 SMTP_PASSWORD={{ smtp_password }}
+MAILS_FROM={{ mails_from | default("no-reply@{{ mail_domain }}") }}
+MAIL_BCC={{ mail_bcc | default('') }}


### PR DESCRIPTION
Closes #202. 

Enables mail settings for from_address and bcc to be set. These are currently able to be set in the instance config section, but get wiped after each deploy.

This PR has a corresponding PR in the main repo: https://github.com/openfoodfoundation/openfoodnetwork/pull/2482 

They should both be able to be merged separately without any problems.