### PR TITLE
Enable copy-paste of PR name from Github

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -12,8 +12,11 @@ user: ofn-admin
 # to connect using SSH instead of just passwords.
 ssh_pubkey: "{{ lookup('file', '~/.ssh/{{ ssh_pubkey_name }}') }}"
 
-git_repo: https://github.com/openfoodfoundation/openfoodnetwork.git
-git_version: master
+# You can paste the repo/branch straight from a github PR here, like: "Contributor22:new_feature"
+github_key: openfoodfoundation:master
+
+git_repo: "https://github.com/{{ github_key.split(':')[0] }}/openfoodnetwork.git"
+git_version: "{{ github_key.split(':')[1] }}"
 
 l10n_git_version: HEAD
 


### PR DESCRIPTION
This isn't really part of an issue or an epic, but we talked about how it would be nice to have.

This enables copy-pasting of a PR's name from a Github page so you don't have to type the repo and branch name out separately in two places, for example when staging things for testing.

**Copy:** 
![screenshot from 2018-07-19 19-25-22](https://user-images.githubusercontent.com/9029026/42962691-142c2504-8b8a-11e8-9a55-e03adebc894e.png)

**Paste:**
![screenshot from 2018-07-19 19-30-31](https://user-images.githubusercontent.com/9029026/42962874-8edbf6b2-8b8a-11e8-8463-f867abce90b5.png)


P.S. I'm not invoicing for this one, just wanted to add this to make staging PRs a bit nicer. :heart: 
