### PR TITLE
Speed up apt

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -9,32 +9,29 @@
   #TODO remove unnecesary packages from this list.
 - name: install base packages
   apt:
-    pkg="{{ item }}"
-    state=present
+    name: "{{ packages }}"
   become: yes
-  with_items:
-    - acl
-    - build-essential
-    - git-core
-    - nodejs
-    - imagemagick
-    - curl
-    - python-pycurl
-    - python-psycopg2 # needed for some ansible libraries
-    - python3-psycopg2
-    - python-software-properties
-    - libpq-dev
-    - tklib
-    - zlib1g-dev
-    - libssl-dev
-    #- libreadline-gplv2-dev
-    - libxml2
-    - libxml2-dev
-    - libxslt1-dev
-    - memcached
-    - ranger
-    #- fontconfig # needed for phantomjs
-    #- nfs-common # make virtualbox faster
+  vars:
+    packages:
+      - acl
+      - build-essential
+      - git-core
+      - nodejs
+      - imagemagick
+      - curl
+      - python-pycurl
+      - python-psycopg2 # needed for some ansible libraries
+      - python3-psycopg2
+      - python-software-properties
+      - libpq-dev
+      - tklib
+      - zlib1g-dev
+      - libssl-dev
+      - libxml2
+      - libxml2-dev
+      - libxslt1-dev
+      - memcached
+      - ranger
   tags: packages
 
 # Remove monit if still installed. The notified handlers will run only once

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,7 +2,8 @@
 
 - name: update apt
   apt:
-    update_cache=yes
+    update_cache: yes
+    cache_valid_time: 86400 # seconds = 60*60*24 seconds = 24 hours
   become: yes
   tags: packages
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -14,25 +14,34 @@
   become: yes
   vars:
     packages:
-      - acl
-      - build-essential
-      - git-core
-      - nodejs
-      - imagemagick
-      - curl
+      # Ansible support
       - python-pycurl
-      - python-psycopg2 # needed for some ansible libraries
+      - python-psycopg2
       - python3-psycopg2
       - python-software-properties
-      - libpq-dev
+
+      # unknown why needed
+      - acl
+      - nodejs
+      - curl
       - tklib
+      - ranger
+
+      # build ruby and gems
+      - build-essential
+
+      # manage code
+      - git-core
+
+      # OFN dependencies
+      - imagemagick
+      - libpq-dev
       - zlib1g-dev
       - libssl-dev
       - libxml2
       - libxml2-dev
       - libxslt1-dev
       - memcached
-      - ranger
   tags: packages
 
 # Remove monit if still installed. The notified handlers will run only once

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -7,7 +7,6 @@
   become: yes
   tags: packages
 
-  #TODO remove unnecesary packages from this list.
 - name: install base packages
   apt:
     name: "{{ packages }}"
@@ -20,12 +19,13 @@
       - python3-psycopg2
       - python-software-properties
 
-      # unknown why needed
+      # unknown why or if needed
+      # The playbooks run without these dependencies,
+      # but they may be hidden run time dependencies
+      # like imagemagick.
       - acl
       - nodejs
       - curl
-      - tklib
-      - ranger
 
       # build ruby and gems
       - build-essential


### PR DESCRIPTION
The official documentation recommends this approach of passing all packages to apt at once which is much more efficient than calling apt 20 times.

I also removed two packages from the list. They are not on my dev machine and I never needed them. I think they were for a previous admin.