### PR TITLE
Use Ansibles's script module instead of copying

### DIFF
--- a/roles/dbserver/files/fix_pg_encoding.sh
+++ b/roles/dbserver/files/fix_pg_encoding.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Rails expects unicode as database encoding, but Posgres may have a different default.
+# Since Rails doesn't set the encoding explicitly when creating databases,
+# we need to change the template database.
+#
+# https://stackoverflow.com/questions/16736891/pgerror-error-new-encoding-utf8-is-incompatible
+
+psql -U postgres <<'HEREDOC'
+update pg_database set datistemplate=false where datname='template1';
+drop database Template1;
+create database template1 with owner=postgres encoding='UTF-8' lc_collate='en_US.utf8' lc_ctype='en_US.utf8' template template0;
+update pg_database set datistemplate=true where datname='template1';
+HEREDOC

--- a/roles/dbserver/files/fix_pg_encoding.sql
+++ b/roles/dbserver/files/fix_pg_encoding.sql
@@ -1,4 +1,0 @@
-update pg_database set datistemplate=false where datname='template1';
-drop database Template1;
-create database template1 with owner=postgres encoding='UTF-8' lc_collate='en_US.utf8' lc_ctype='en_US.utf8' template template0;
-update pg_database set datistemplate=true where datname='template1';

--- a/roles/dbserver/tasks/main.yml
+++ b/roles/dbserver/tasks/main.yml
@@ -27,32 +27,10 @@
   become: yes
   become_user: "{{ unicorn_user }}"
 
-
-# TODO: Surely there's a way to pipe this script over rather than copying and removing it?
-
-- name: copy fix_pg_encoding PG script
-  copy:
-    src=fix_pg_encoding.sql
-    dest={{ unicorn_home_path }}
-  become: yes
-  become_user: "{{ unicorn_user }}"
-  tags:
-    - pg-en
-    - skip_ansible_lint
-
+# Rails expects unicode databases. See the script for more details.
 - name: fix postgres db encoding problem
-  command: psql -U postgres -f {{ unicorn_home_path }}/fix_pg_encoding.sql
+  script: fix_pg_encoding.sh
   become: yes
   become_user: postgres
   tags:
     - pg-en
-    - skip_ansible_lint
-
-- name: remove fix_pg_encoding PG script
-  file:
-    path={{ unicorn_home_path }}/fix_pg_encoding.sql
-    state=absent
-  become: yes
-  become_user: "{{ unicorn_user }}"
-  tags:
-    - skip_ansible_lint


### PR DESCRIPTION
Using the script module combines our three steps in one. This is simpler
and more robust.

This script will still run every time.