### PR TITLE
Replace depricated features

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 roles_path = ./community:./roles
-hostfile = ./inventory/hosts
+inventory = ./inventory/hosts
 
 callback_whitelist = profile_tasks
 

--- a/playbooks/rollback.yml
+++ b/playbooks/rollback.yml
@@ -6,8 +6,8 @@
   become_user: "{{ unicorn_user }}"
 
   handlers:
-    - include: ../roles/webserver/handlers/main.yml
-    - include: ../roles/deploy/handlers/main.yml
+    - include_tasks: ../roles/webserver/handlers/main.yml
+    - include_tasks: ../roles/deploy/handlers/main.yml
 
   roles:
     - role: rollback

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,5 @@
 ---
-- include: playbooks/python.yml
-- include: playbooks/default_user.yml
-- include: playbooks/provision.yml
-- include: playbooks/deploy.yml
+- import_playbook: playbooks/python.yml
+- import_playbook: playbooks/default_user.yml
+- import_playbook: playbooks/provision.yml
+- import_playbook: playbooks/deploy.yml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,5 +6,5 @@
     - name: test
       debug: msg="{{ foo }} {{ foo2 }}"
 
-  # include: ../provision.yml
+  # import_playbook: ../provision.yml
 


### PR DESCRIPTION
I see several warnings each time I run `ansible-playbook`. I'm using Ansible 2.6 at the moment. Some of these feature have been available since Ansible 2.4. Which Ansible versions are you using? Do we need to define a minimum version to support?

