### PR TITLE
Add backup sysadmins to katuma servers

### DIFF
--- a/inventory/group_vars/es.yml
+++ b/inventory/group_vars/es.yml
@@ -19,3 +19,5 @@ users_sysadmin:
   - enricostn
   - dani
   - pau
+  - matt
+  - maikel


### PR DESCRIPTION
In case either Dani or Enrico have a "stuck at the dentist" situation
while I'm on holidays.

Jokes aside, we decided with @Matt-Yorkley to let him use our staging
servers from now on as a proof-of-concept for our goal of
granting access for all sysadmins to all servers. This will let us spot
the bottlenecks and areas we will need to work on.