### PR TITLE
Remove HSTS header and old unused header

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -138,8 +138,6 @@ nginx_sites:
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;
-      #add_header Content-Security-Policy "default-src self" always;
-      add_header Strict-Transport-Security "max-age=31536000" always;
 
       gzip on;
       gzip_disable "msie6";


### PR DESCRIPTION
Closes #216. 

Removes the HSTS header to ensure it doesn't get written twice by nginx and Rails, resulting in an invalid value.

Also removed an old commented-out header line. 