### PR TITLE
Fix locale for UK servers

### DIFF
--- a/inventory/group_vars/uk.yml
+++ b/inventory/group_vars/uk.yml
@@ -4,7 +4,7 @@
 checkout_zone: Europe
 country_code: GB
 currency: GBP
-locale: en-GB
+locale: en_GB
 language: en_GB.UTF-8
 language_packages:
   - language-pack-en-base


### PR DESCRIPTION
Our locale variable was outdated on ofn-install. It looks like it was manually changed on the server, but recently got overwritten with the old variable when I provisioned UK prod, so we lost localised translations for `en_GB`.