### PR TITLE
Allow running default_user task multiple times

### DIFF
--- a/playbooks/default_user.yml
+++ b/playbooks/default_user.yml
@@ -3,7 +3,6 @@
 # default user (ubuntu) and wont let this be run as root. But digital ocean images don't.
 - name: default_user
   hosts: ofn_servers
-  remote_user: root
   roles:
     - role: default_user
       become: yes


### PR DESCRIPTION
This task was meant to be executed just in the first provisioning and hence used `root` as `remote_user`.

By removing that argument we can now also use it to add extra authorized keys to the `ofn-admin` user by simply passing `-u ofn-admin` as follows:

```
$ ansible-playbook playbooks/default_user.yml -u ofn-admin --limit=es-staging
```

To run a first provisioning we will need then do it like:

```
$ ansible-playbook playbooks/default_user.yml -u root --limit=es-staging
```