### PR TITLE
Add option to create a swapfile

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -10,3 +10,6 @@
 
 - src: coopdevs.certbot_nginx
   version: 0.0.1
+
+- src: oefenweb.swapfile
+  version: v2.0.7

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -33,6 +33,10 @@ security_autoupdate_mail_to: "{{ developer_email }}"
 
 
 #----------------------------------------------------------------------
+# swapfile variables
+swapfile_size: false
+
+#----------------------------------------------------------------------
 # Rails variables
 ruby_version: 2.1.5
 env:

--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -14,3 +14,7 @@ mail_domain: example.com
 #  - example.com
 #  - www.example.com
 #  - info.example.com
+
+# Size in bytes. You can also use units like 1G, 512MiB or 1000KB. See: `man fallocate`
+# The default is `false`, not installing a swapfile.
+#swapfile_size: 1G

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -18,6 +18,7 @@
 
     - role: oefenweb.swapfile
       become: yes
+      when: swapfile_size != false
       tags: swapfile
 
     - role: unicorn_user # Create unprivileged user to run unicorn

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -16,6 +16,10 @@
       become_user: root
       tags: security
 
+    - role: oefenweb.swapfile
+      become: yes
+      tags: swapfile
+
     - role: unicorn_user # Create unprivileged user to run unicorn
       tags: unicorn_user
 


### PR DESCRIPTION
This can be very useful to avoid running out of memory. It may be that a
server only needs more memory during deployment.

I have been setting this up manually in the past. It would be nice to automate.