### PR TITLE
Allow multiple domains with certbot

### DIFF
--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -6,3 +6,11 @@ rails_env: production
 admin_email: admin@example.com
 
 mail_domain: example.com
+
+# Optional list of subdomains to register in letsencrypt certificate
+# Defaults to {{ domain }} if list is undefined
+#
+#certbot_domains:
+#  - example.com
+#  - www.example.com
+#  - info.example.com

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -54,7 +54,7 @@
     - role: coopdevs.certbot_nginx
       become: yes
       vars:
-        domain_name: "{{ domain }}"
+        domain_name: "{{ certbot_domains | default([domain]) | join(',') }}"
         letsencrypt_email: "{{ developer_email }}"
       when: inventory_hostname != "local_vagrant"
 


### PR DESCRIPTION
Closes #235.

Allows for registering multiple subdomains with letsencrypt by specifying a list. 

The `-d` flag in the certbot certificate command can take a comma-separated list, so we use this. Defaults to the existing `domain` variable if the list is undefined. 

