### PR TITLE
Increase app timeout for UK server

### DIFF
--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -2,3 +2,7 @@
 
 domain: www.openfoodnetwork.org.uk
 rails_env: production
+
+# Otherwise editing enterprise fees times out:
+# https://github.com/openfoodfoundation/openfoodnetwork/issues/2545
+unicorn_timeout: 120


### PR DESCRIPTION
Workaround for https://github.com/openfoodfoundation/openfoodnetwork/issues/2545.

This pull request does not adjust the timeout in nginx. I'm not sure if that is required. An active unicorn could send keepalive packets to signal that it's still there, but busy. I haven't tested that. This may be enough.