### PR TITLE
Add required mail_domain to us host config

### DIFF
--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -1,4 +1,20 @@
 ---
+
 domain: openfoodnetwork.net
 rails_env: production
+
 admin_email: ofn-usa@openfoodnetwork.net
+
+mail_domain: openfoodnetwork.net
+
+# Optional list of subdomains to register in letsencrypt certificate
+# Defaults to {{ domain }} if list is undefined
+#
+#certbot_domains:
+#  - example.com
+#  - www.example.com
+#  - info.example.com
+
+# Size in bytes. You can also use units like 1G, 512MiB or 1000KB. See: `man fallocate`
+# The default is `false`, not installing a swapfile.
+#swapfile_size: 1G


### PR DESCRIPTION
Closes: #169

The mail domain is needed for provisioning to run. Otherwise we get:

```
TASK [unicorn_user : Write OFN environment variables defaults] ****************************************************************************************************************************************************
Monday 27 August 2018  12:17:18 +1000 (0:00:00.034)       0:03:17.723 ********* 
fatal: [openfoodnetwork.net]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'mail_domain' is undefined"}
```