### PR TITLE
Support mail via TLS

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -42,5 +42,8 @@ smtp_username:
 smtp_password:
 
 # Optional mail settings
+## Connection type 'TLS' means STARTTLS usually on port 587
+## Connection type 'SSL' means SSL/TLS usually on port 465
+# mail_secure_connection: 'TLS'
 # mails_from: from_address@example.com
 # mail_bcc: bcc_me@example.com

--- a/roles/unicorn_user/templates/defaults.j2
+++ b/roles/unicorn_user/templates/defaults.j2
@@ -7,6 +7,9 @@ RAILS_ENV={{ rails_env }}
 MAIL_DOMAIN={{ mail_domain }}
 MAIL_HOST={{ mail_host }}
 MAIL_PORT={{ mail_port }}
+{% if mail_secure_connection is defined %}
+  MAIL_SECURE_CONNECTION={{ mail_secure_connection  }}
+{% endif %}
 SMTP_USERNAME={{ smtp_username }}
 SMTP_PASSWORD={{ smtp_password }}
 {% if mails_from is defined %}


### PR DESCRIPTION
Since https://github.com/openfoodfoundation/openfoodnetwork/pull/2583/ we can set some encryption for email.