### PR TITLE
Install compatible Ansible version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python: "2.7"
 install:
   # - pip install dopy
   # - pip install httplib2
-  - pip install ansible
+  - pip install 'ansible<2.7.0'
   - pip install ansible-lint
 
 script:


### PR DESCRIPTION
The current version of jdauphant.nginx is not compatible with Ansible
2.7.0. The error was:

> 
>   ERROR! 'always_run' is not a valid attribute for a Handler
> 
>   The error appears to have been in
>   '/home/travis/build/openfoodfoundation/ofn-install/community/jdauphant.nginx/handlers/main.yml':
>   line 17, column 3, but may
>   be elsewhere in the file depending on the exact syntax problem.