### PR TITLE
Add Ha-Ri core team devs SSH key to all servers

### DIFF
--- a/inventory/group_vars/au.yml
+++ b/inventory/group_vars/au.yml
@@ -22,3 +22,6 @@ users_sysadmin:
   - rohan
   - enricostn
   - pau
+  - kristina
+  - luis
+  - matt

--- a/inventory/group_vars/de.yml
+++ b/inventory/group_vars/de.yml
@@ -21,3 +21,4 @@ users_sysadmin:
   - pau
   - luis
   - matt
+  - kristina

--- a/inventory/group_vars/es.yml
+++ b/inventory/group_vars/es.yml
@@ -21,3 +21,5 @@ users_sysadmin:
   - pau
   - matt
   - maikel
+  - kristina
+  - luis

--- a/inventory/group_vars/fr.yml
+++ b/inventory/group_vars/fr.yml
@@ -24,3 +24,4 @@ users_sysadmin:
   - pau
   - enricostn
   - luis
+  - kristina

--- a/inventory/group_vars/uk.yml
+++ b/inventory/group_vars/uk.yml
@@ -21,3 +21,4 @@ users_sysadmin:
   - pau
   - maikel
   - kristina
+  - luis

--- a/inventory/group_vars/us.yml
+++ b/inventory/group_vars/us.yml
@@ -22,3 +22,7 @@ users_sysadmin:
   - maikel
   - tim
   - ravi
+  - matt
+  - kristina
+  - luis
+  - pau


### PR DESCRIPTION
Closes #180 

If there's a production issue in any of the OFN instances any Ha or Ri
dev can put the sysadmin hat on and fix it.

Access to production machines is also needed to investigate production
logs as well as production data when trying to fix high severity issues,
like happened recently.