### PR TITLE
Enable passwordless createdb and dropdb

### DIFF
--- a/roles/dbserver/templates/pgpass.j2
+++ b/roles/dbserver/templates/pgpass.j2
@@ -1,2 +1,1 @@
-localhost:*:{{ db }}:{{ db_user }}:{{ db_password }}
-
+localhost:*:*:{{ db_user }}:{{ db_password }}


### PR DESCRIPTION
Some Postgresql commands don't connect to a database. If our pgpass file
specifies a database, the password can't be used by those commands. By
defining `*` for any database, we can use any Postgres tool on the
command line without a password. The potential of conflict is minimal as
we would choose another database user if we wanted to separate access
scopes to databases.

These commands need to be passwordless for deployment scripts.