### PR TITLE
Update jdauphant.nginx from v2.7.4 to v2.8.1

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -6,7 +6,7 @@
   version: 3.0.0
 
 - src: jdauphant.nginx
-  version: v2.7.4
+  version: v2.8.1
 
 - src: coopdevs.certbot_nginx
   version: 0.0.1


### PR DESCRIPTION
## Description

Closes #207 

This contains https://github.com/jdauphant/ansible-role-nginx/commit/8f2b741a9ab3465cc7f64881c3f873e06c828099 which fixes #207. Check https://github.com/jdauphant/ansible-role-nginx/compare/v2.7.4...v2.8.1 for the full list of changes. I think it's safe to update.