### PR TITLE
Serve multiple subdomains

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -118,7 +118,7 @@ nginx_sites:
     - |
       listen 80;
       listen [::]:80;
-      server_name {{ domain }};
+      server_name {{ server_name | default(domain) }};
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;
@@ -136,7 +136,7 @@ nginx_sites:
     - |
       listen 443 ssl http2;
       listen [::]:443 ssl http2;
-      server_name {{ domain }};
+      server_name {{ server_name | default(domain) }};
       root {{ app_root }}/public;
 
       ssl_certificate      /etc/letsencrypt/live/{{ domain }}/fullchain.pem;

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -129,7 +129,7 @@ nginx_sites:
       }
 
       location / {
-        return 301 https://$server_name$request_uri;
+        return 301 https://$host$request_uri;
       }
 
   ofn_443:

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -122,7 +122,6 @@ nginx_sites:
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;
-      #add_header Content-Security-Policy "default-src self" always;
 
       location '/.well-known/acme-challenge' {
         default_type "text/plain";
@@ -162,8 +161,6 @@ nginx_sites:
         gzip_static on;
         expires max;
         add_header Cache-Control public;
-        #add_header Last-Modified "";
-        #add_header ETag "";
       }
 
       error_page 500 502 503 504 /500.html;

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -139,8 +139,8 @@ nginx_sites:
       server_name {{ server_name | default(domain) }};
       root {{ app_root }}/public;
 
-      ssl_certificate      /etc/letsencrypt/live/{{ domain }}/fullchain.pem;
-      ssl_certificate_key  /etc/letsencrypt/live/{{ domain }}/privkey.pem;
+      ssl_certificate      /etc/letsencrypt/live/{{ certbot_cert_name | default(domain) }}/fullchain.pem;
+      ssl_certificate_key  /etc/letsencrypt/live/{{ certbot_cert_name | default(domain) }}/privkey.pem;
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;

--- a/inventory/host_vars/alpha.katuma.org/config.yml
+++ b/inventory/host_vars/alpha.katuma.org/config.yml
@@ -5,3 +5,11 @@ rails_env: production
 admin_email: info@coopdevs.org
 
 mail_domain: katuma.org
+
+certbot_domains:
+  - app.katuma.org
+  - alpha.katuma.org
+
+certbot_cert_name: app.katuma.org
+
+server_name: "alpha.katuma.org app.katuma.org"

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -61,7 +61,9 @@
       vars:
         domain_name: "{{ certbot_domains | default([domain]) | join(',') }}"
         letsencrypt_email: "{{ developer_email }}"
+        certbot_nginx_cert_name: "{{ certbot_cert_name | default(None) }}"
       when: inventory_hostname != "local_vagrant"
+      tags: certbot
 
     - role: jdauphant.nginx
       become: yes


### PR DESCRIPTION
## Description

This change gives support for serving multiple subdomains from the same nginx server using HTTPS. 

This solves the problem of having to migration from alpha.katuma.org to app.katuma.org. This has been long overdue and we need it to improve the perception potential customers have about the project. It's been already a year passed the alpha!

This will be useful for other instances facing a similar problems due to increased flexibility.

## Changes

This introduces the `server_name` var as a way to provide a nginx server name other than the domain plus the `certbot_cert_name` var to allow also setting a certificate name other than the domain.

Note this depends on https://github.com/coopdevs/certbot_nginx/pull/7.

I carefully ordered the commits so you can follow easily. Check them if there's something you don't understand.