### PR TITLE
Install datadog agent in provisioning

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -13,3 +13,6 @@
 
 - src: oefenweb.swapfile
   version: v2.0.7
+
+- src: Datadog.datadog
+  version: 2.4.0

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -47,3 +47,9 @@ smtp_password:
 # mail_secure_connection: 'TLS'
 # mails_from: from_address@example.com
 # mail_bcc: bcc_me@example.com
+
+# Datadog monitoring. See
+# https://github.com/openfoodfoundation/ofn-install/issues/287 for details.
+# Note we have a single OFN account where all servers send their metrics to.
+#
+# datadog_key: 'API_key_for_the_OFN_account'

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -69,3 +69,10 @@
 
     - role: webserver # Build the unicorn webserver.
       tags: webserver
+
+    - role: Datadog.datadog
+      become: yes
+      vars:
+        datadog_api_key: "{{ datadog_key }}"
+      when: datadog_key is defined
+      tags: datadog


### PR DESCRIPTION
## Description

This uses https://github.com/DataDog/ansible-datadog to install the agent with the provided `datadog_key`. Note this variable needs to specified in the secrets file for the agent to work.

Note you will need to execute `ansible-galaxy -r bin/requirements.yml install` before provisioning to fetch this new role.

## Production instances provisioned

- [x] Katuma
- [ ] UK
- [ ] France
- [ ] US

## Missing

- [x] Entry in example