### PR TITLE
Increase FR timeouts

### DIFF
--- a/inventory/host_vars/staging.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/staging.openfoodfrance.org/config.yml
@@ -6,3 +6,5 @@ rails_env: staging
 admin_email: admin@openfoodfrance.org
 
 mail_domain: openfoodfrance.org
+
+unicorn_timeout: 120

--- a/inventory/host_vars/www.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/www.openfoodfrance.org/config.yml
@@ -6,3 +6,5 @@ rails_env: production
 admin_email: admin@openfoodfrance.org
 
 mail_domain: openfoodfrance.org
+
+unicorn_timeout: 120


### PR DESCRIPTION
Increasing timeouts for FR servers due to issue: https://github.com/openfoodfoundation/openfoodnetwork/issues/3148

Same as #238

This change is already done in prod manually:
vim /home/openfoodnetwork/apps/openfoodnetwork/shared/config/unicorn.rb
/etc/init.d/unicorn_openfoodnetwork restart
vim -> change timeout from 30 to 90