### PR TITLE
Enable 1G swap file on Katuma

### DIFF
--- a/inventory/host_vars/alpha.katuma.org/config.yml
+++ b/inventory/host_vars/alpha.katuma.org/config.yml
@@ -13,3 +13,5 @@ certbot_domains:
 certbot_cert_name: app.katuma.org
 
 server_name: "alpha.katuma.org app.katuma.org"
+
+swapfile_size: 1G


### PR DESCRIPTION
Until we don't set up a new 8Gb-RAM new server, which is going to happen this month, this will let us sleep.

![screenshot from 2018-12-03 13-25-10](https://user-images.githubusercontent.com/762088/49373576-e04bf300-f6fe-11e8-937c-c3a2db51c623.png)

:point_up: This is its usage under regular conditions