### PR TITLE
Replace FQDN in inventory with new app.katuma.org

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -77,7 +77,7 @@ us-staging
 # Spain
 
 [es-prod]
-alpha.katuma.org ansible_host=51.15.136.157
+app.katuma.org ansible_host=51.15.136.157
 
 [es-staging]
 staging.katuma.org ansible_host=51.15.216.10


### PR DESCRIPTION
We just added the subdomain app.katuma.org to serve the app besides the old alpha.katuma.org. We want to get rid of the *alpha*ness of that URL so people don't get the wrong impression. For now, Nginx serves both.