### PR TITLE
Notify Slack on deploy and provision

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -77,3 +77,11 @@
         datadog_api_key: "{{ datadog_key }}"
       when: datadog_key is defined
       tags: datadog
+
+  tasks:
+    - name: notify slack
+      slack:
+        token: "T02G54U79/BF25P9F7A/DJdtYaLLUpRJPiu72d8NqgGg"
+        msg: '{{ inventory_hostname }} provisioned'
+        channel: "#devops-notifications"
+        username: ansible

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -84,4 +84,4 @@
         token: "T02G54U79/BF25P9F7A/DJdtYaLLUpRJPiu72d8NqgGg"
         msg: '{{ inventory_hostname }} provisioned'
         channel: "#devops-notifications"
-        username: ansible
+        username: "ansible executed by {{ lookup('env','USER') }}"

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -61,6 +61,6 @@
 - name: notify slack
   slack:
     token: "T02G54U79/BF25P9F7A/DJdtYaLLUpRJPiu72d8NqgGg"
-    msg: '{{ inventory_hostname }} deployed'
+    msg: '`{{ git_version }}` deployed to {{ inventory_hostname }}'
     channel: "#devops-notifications"
     username: ansible

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -63,4 +63,4 @@
     token: "T02G54U79/BF25P9F7A/DJdtYaLLUpRJPiu72d8NqgGg"
     msg: '`{{ git_version }}` deployed to {{ inventory_hostname }}'
     channel: "#devops-notifications"
-    username: ansible
+    username: "ansible executed by {{ lookup('env','USER') }}"

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -57,3 +57,10 @@
   command: bash -lc "bundle exec whenever --set 'environment={{ rails_env }}' --update-crontab"
   args:
     chdir: "{{ current_path }}"
+
+- name: notify slack
+  slack:
+    token: "T02G54U79/BF25P9F7A/DJdtYaLLUpRJPiu72d8NqgGg"
+    msg: '{{ inventory_hostname }} deployed'
+    channel: "#devops-notifications"
+    username: ansible

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -199,3 +199,4 @@
     - restart unicorn
     - restart delayed job service
     - update whenever
+    - notify slack


### PR DESCRIPTION
Just that. It displays the following message in the #devops-notifications channel of our Slack.

![captura de pantalla 2018-12-28 a les 12 23 53](https://user-images.githubusercontent.com/762088/50513952-80493200-0a9b-11e9-9005-13ea83237c6c.png)

when deploying and provisioning. Note that the message will tell what action was taken, either deploy or provision.

This will provide greater visibility to the whole team, not just the person executing ansible or devs.