### PR TITLE
Don’t compare to boolean literal

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -18,7 +18,6 @@
 
     - role: oefenweb.swapfile
       become: yes
-      when: swapfile_size != false
       tags: swapfile
 
     - role: unicorn_user # Create unprivileged user to run unicorn


### PR DESCRIPTION
That is what ansible-lint complains about. It fixes the build error

```
$ ansible-lint site.yml --exclude=community
[601] Don't compare to literal True/False
/home/travis/build/openfoodfoundation/ofn-install/playbooks/provision.yml:21
      when: swapfile_size != false
The command "ansible-lint site.yml --exclude=community" exited with 2.
```
There is no need to conditionally execute the swapfile role. It will skip all tasks if no `swapfile_size` is defined.