### PR TITLE
Update oefenweb.swapfile from v2.0.7 to v2.0.14

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -12,7 +12,7 @@
   version: 0.0.1
 
 - src: oefenweb.swapfile
-  version: v2.0.7
+  version: v2.0.14
 
 - src: Datadog.datadog
   version: 2.4.0


### PR DESCRIPTION
The only relevant change I found is https://github.com/Oefenweb/ansible-swapfile/commit/ca4ef15d2419b8582f13a3c7b4e027372d539c68.

Also, this update includes support for Ubuntu 18.04.