### PR TITLE
Do not serve traffic on alpha.katuma.org anymore

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -121,7 +121,7 @@ nginx_sites:
     - |
       listen 80;
       listen [::]:80;
-      server_name {{ server_name | default(domain) }};
+      server_name {{ domain }};
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;
@@ -139,7 +139,7 @@ nginx_sites:
     - |
       listen 443 ssl http2;
       listen [::]:443 ssl http2;
-      server_name {{ server_name | default(domain) }};
+      server_name {{ domain }};
       root {{ app_root }}/public;
 
       ssl_certificate      /etc/letsencrypt/live/{{ certbot_cert_name | default(domain) }}/fullchain.pem;

--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -1,5 +1,5 @@
 ---
-domain: alpha.katuma.org
+domain: app.katuma.org
 rails_env: production
 
 admin_email: info@coopdevs.org
@@ -11,7 +11,5 @@ certbot_domains:
   - alpha.katuma.org
 
 certbot_cert_name: app.katuma.org
-
-server_name: "alpha.katuma.org app.katuma.org"
 
 swapfile_size: 1G


### PR DESCRIPTION
Now that we got app.katuma.org up and running we haven't dropped alpha.katuma.org but moved to a permanent redirect in https://github.com/coopdevs/katuma-provisioning/pull/14/.

We will eventually remove it and have app.katuma.org only. Meanwhile, we can have a bit simpler nginx sites.