### PR TITLE
Install used bundler version on deploy

### DIFF
--- a/playbooks/development.yml
+++ b/playbooks/development.yml
@@ -24,11 +24,6 @@
         - "{{ unicorn_user }}"
       tags: ruby
 
-    - role: bundler # Install bundler on its own here as it has to be installed after zzet.rbenv
-      become: yes
-      become_user: "{{ unicorn_user }}"
-      tags: bundler
-
     - role: dbserver # Set up database server and user for the app.
       tags: dbserver
       db_user_roles: SUPERUSER,CREATEDB

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -41,11 +41,6 @@
         - "{{ unicorn_user }}"
       tags: ruby
 
-    - role: bundler # Install bundler on its own here as it has to be installed after zzet.rbenv
-      become: yes
-      become_user: "{{ unicorn_user }}"
-      tags: bundler
-
     - role: app # Build the app directory structure and support files.
       become: yes
       become_user: "{{ unicorn_user }}"

--- a/roles/bundler/tasks/main.yml
+++ b/roles/bundler/tasks/main.yml
@@ -1,8 +1,0 @@
---- # Bundler - here separately as it needs to load after the rbenv role.
-
-- name: install bundler
-  # This needs to be run inside a bash shell to initialise rbenv
-  # See http://stackoverflow.com/questions/22115936/install-bundler-gem-using-ansible
-  command: bash -lc "RBENV_VERSION='{{ ruby_version }}' gem install bundler --no-ri --no-rdoc"
-  args:
-    creates: "~/.rbenv/shims/bundler"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -78,6 +78,15 @@
   when: s3_backups_bucket != ""
   tags: symlink
 
+- name: install bundler
+  # This needs to be run inside a bash shell to initialise rbenv
+  # See http://stackoverflow.com/questions/22115936/install-bundler-gem-using-ansible
+  command: bash -lc "./script/install-bundler --no-ri --no-rdoc"
+  args:
+    chdir: "{{ build_path }}"
+  register: bundler
+  changed_when: "bundler.stdout != ''"
+
 - name: bundle install app dependencies
   #TODO make the "--without development" part conditional on rails_env
   # Note: the 'LANG=...' is a fix for broken rubygems utf8 handling.


### PR DESCRIPTION
Closes https://github.com/openfoodfoundation/ofn-install/issues/74.
https://openfoodnetwork.slack.com/archives/C0DNLAZC7/p1546618893018000

Installing during deploy instead of provision enables us to read the
Gemfile.lock file which contains the last used bundler version.

The newest bundler v2 doesn't support our Ruby 2.1.5. We need to install
an older bundler.

### Dependencies

This depends on https://github.com/openfoodfoundation/openfoodnetwork/pull/3302 for the install script.