### PR TITLE
Update namespace for Rake task in db setup script

### DIFF
--- a/scripts/db-setup.sh
+++ b/scripts/db-setup.sh
@@ -18,4 +18,4 @@ spree123
 EOF
 echo
 echo "Load default data for development environment..."
-"$bundle" exec rake openfoodnetwork:dev:load_sample_data
+"$bundle" exec rake ofn:dev:load_sample_data


### PR DESCRIPTION
This PR changes the reference of a namespace updated by [openfoodnetwork/openfoodnetwork#3418](https://github.com/openfoodfoundation/openfoodnetwork/pull/3418)

No other business logic changes, in order test it will require running the `scripts/db-setup.sh` to ensure it executes correctly.

### This PR is dependent on [openfoodnetwork/openfoodnetwork#3418](https://github.com/openfoodfoundation/openfoodnetwork/pull/3418)
