### PR TITLE
Update certbot_nginx from 0.0.1 to 0.0.3

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -9,7 +9,7 @@
   version: v2.8.1
 
 - src: coopdevs.certbot_nginx
-  version: 0.0.1
+  version: 0.0.3
 
 - src: oefenweb.swapfile
   version: v2.0.14


### PR DESCRIPTION
Related to #324

This installs cerbot v0.28 needed to stop using TLS-SNI-01 as described
in https://community.letsencrypt.org/t/how-to-stop-using-tls-sni-01-with-certbot/83210.