### PR TITLE
Dont spam Slack when provisioning vagrant dev boxes

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -80,3 +80,4 @@
         msg: '{{ inventory_hostname }} provisioned'
         channel: "#devops-notifications"
         username: "ansible executed by {{ lookup('env','USER') }}"
+      when: inventory_hostname != "local_vagrant"

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -64,3 +64,4 @@
     msg: '`{{ git_version }}` deployed to {{ inventory_hostname }}'
     channel: "#devops-notifications"
     username: "ansible executed by {{ lookup('env','USER') }}"
+  when: inventory_hostname != "local_vagrant"


### PR DESCRIPTION
I've been playing with a Vagrant dev setup that we might use for an OFN UK hackday and realised that we probably don't need to notify Slack every time a Vagrant box is updated. :trollface: 