### PR TITLE
Remove all traces of bugsnag initializer

### DIFF
--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -35,18 +35,10 @@
     - { src: "seed.sh.j2", dest: "{{ config_path }}/seed.sh" }
   tags: app_templates
 
-# Note this requires the `bugsnag_key` var to be specified otherwise no
-# template will be copied
-- name: copy the bugsnag's initializer file into the shared folder
-  template:
-    src: "bugsnag.rb.j2"
-    dest: "{{ config_path }}/bugsnag.rb"
-    owner: "{{ unicorn_user }}"
-    mode: 0775
-  tags:
-    - app_templates
-    - bugsnag
-  when: bugsnag_key is defined
+- name: remove bugsnag's initializer from the shared folder
+  file:
+    path: "{{ config_path }}/bugsnag.rb"
+    state: absent
 
 - name: copy the db2fog file into the shared folder
   template:

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -26,3 +26,5 @@ STRIPE_CLIENT_ID: {{ stripe_client_id }}
 STRIPE_INSTANCE_SECRET_KEY: {{ stripe_instance_secret_key }}
 STRIPE_INSTANCE_PUBLISHABLE_KEY: {{ stripe_instance_publishable_key }}
 STRIPE_ENDPOINT_SECRET: {{ stripe_endpoint_secret }}
+
+BUGSNAG_API_KEY: {{ bugsnag_key }}

--- a/roles/app/templates/bugsnag.rb.j2
+++ b/roles/app/templates/bugsnag.rb.j2
@@ -1,5 +1,0 @@
-Bugsnag.configure do |config|
-  config.api_key = "{{ bugsnag_key }}"
-  config.notify_release_stages = %w(production staging)
-  config.use_ssl = true
-end

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -56,17 +56,6 @@
     - { src: "{{ config_path }}/post-receive", dest: "{{ build_path }}/.git/hooks/post-receive" }
   tags: symlink
 
-- name: symlink the bugsnag file into the config folder
-  file:
-    src="{{ config_path }}/bugsnag.rb"
-    dest={{ build_path }}/config/initializers/bugsnag.rb
-    state=link
-    force=yes
-    owner={{ unicorn_user }}
-    mode=0775
-  when: bugsnag_key != "none"
-  tags: symlink
-
 - name: symlink the db2fog file into the config folder
   file:
     src="{{ config_path }}/db2fog.rb"


### PR DESCRIPTION
This has been moved to the app's `config/initializers/` instead where it doesn't need neither templates nor symlink. It's just about providing the BUGSNAG_API_KEY env var, which is set in both the unicorn service and `/etc/default/openfoodnetwork`.

As a result, it'll fix the issue that both Katuma and OFF are facing where the `config/initializer/bugsnag.rb` symlink to `shared/config/bugsnag.rb` does not exist thus, nothing gets notified to Bugsnag since December 3rd (according to customer support).