### PR TITLE
Remove old staging1.openfoodnetwork.com.au

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -19,7 +19,6 @@ www.openfoodnetwork.org.au
 prod2.openfoodnetwork.org.au
 
 [au-staging]
-staging1.openfoodnetwork.com.au
 staging.openfoodnetwork.org.au
 
 [au:children]


### PR DESCRIPTION
This removes the old server from the inventory. Ansible complains that it is unreachable when provisioning.