### PR TITLE
Enable nl_BE locale for the Belgian instance

### DIFF
--- a/inventory/group_vars/be.yml
+++ b/inventory/group_vars/be.yml
@@ -5,7 +5,7 @@ checkout_zone: Europe
 country_code: BE
 currency: EUR
 locale: fr_BE
-available_locales: fr_BE,de_DE,en_BE
+available_locales: fr_BE,de_DE,en_BE,nl_BE
 language: en_US.UTF-8
 language_packages:
   - language-pack-en-base


### PR DESCRIPTION
Last time we deployed a custom branch based on v1.27.0 plus nl_BE but it was one-time change that needs to be persisted here.

Now Theo complains the server lost its nl_BE translation. See https://openfoodnetwork.slack.com/archives/CFU9N7TGB/p1552397538005900