### PR TITLE
Make S3 and Bugsnag optional

### DIFF
--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -18,13 +18,17 @@ CHECKOUT_ZONE: {{ checkout_zone }}
 
 GOOGLE_MAPS_API_KEY: {{ google_maps_api_key }}
 
+{% if s3_backups_bucket is defined %}
 S3_BACKUPS_BUCKET: {{ s3_backups_bucket }}
 S3_ACCESS_KEY: {{ s3_access_key }}
 S3_SECRET: {{ s3_secret }}
+{% endif %}
 
 STRIPE_CLIENT_ID: {{ stripe_client_id }}
 STRIPE_INSTANCE_SECRET_KEY: {{ stripe_instance_secret_key }}
 STRIPE_INSTANCE_PUBLISHABLE_KEY: {{ stripe_instance_publishable_key }}
 STRIPE_ENDPOINT_SECRET: {{ stripe_endpoint_secret }}
 
+{% if bugsnag_key is defined %}
 BUGSNAG_API_KEY: {{ bugsnag_key }}
+{% endif %}


### PR DESCRIPTION
Without this conditional checks if you don't have these services set up the provisioning will fail. IMO having backups and error tracking shouldn't be optional but decoupling this discussion from the
provisioning will buy some time.

Without it at least the German instance can't be provisioned (I bet they don't have Bugsnag at least). This is exactly what Brandy had to deal with in https://openfoodnetwork.slack.com/archives/C0DNLAZC7/p1552393240006500. Fortunately, she managed to get it working.

**This still needs to be tested in staging**