### PR TITLE
Fix fatal missing database errors when doing a fresh install

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -99,6 +99,21 @@
   set_fact:
     timestamp: "{{ ansible_date_time.date }}-{{ ansible_date_time.hour }}{{ ansible_date_time.minute }}{{ ansible_date_time.second }}"
 
+#--------------------------
+# Check the database status
+
+- name: check database status
+  command: psql -h {{ db_host }} -U {{ db_user }} -d {{ db }} -c "SELECT true FROM pg_tables WHERE tablename = 'order_cycles';"
+  register: table_exists
+  ignore_errors: yes
+  tags:
+    - rake
+    - skip_ansible_lint
+
+- debug: msg="{{ table_exists.stdout }}"
+  tags: rake
+- debug: msg="{{ table_exists.stderr }}"
+  tags: rake
 
 #--------------------------
 # Create a rollback release
@@ -107,10 +122,12 @@
   command: bash -c "set -o pipefail && pg_dump -h '{{ db_host }}' -U '{{ db_user }}' '{{ db }}' | gzip > '{{ rollback_sql_path }}'"
   args:
     creates: "{{ rollback_sql_path }}"
+  when: table_exists.stderr.find('does not exist') == -1
 
 - name: create a database backup version
   command: cp {{ rollback_sql_path }} {{ releases_path }}/{{ timestamp }}.sql.gz
   tags: skip_ansible_lint
+  when: table_exists.stderr.find('does not exist') == -1
 
 - name: create a repo rollback version
   command: mv {{ current_path }} {{ rollback_path }} removes={{ current_path }}
@@ -130,19 +147,6 @@
 
 #--------------------
 # Update the database
-
-- name: check database status
-  command: psql -h {{ db_host }} -U {{ db_user }} -d {{ db }} -c "SELECT true FROM pg_tables WHERE tablename = 'order_cycles';"
-  register: table_exists
-  ignore_errors: yes
-  tags:
-    - rake
-    - skip_ansible_lint
-
-- debug: msg="{{ table_exists.stdout }}"
-  tags: rake
-- debug: msg="{{ table_exists.stderr }}"
-  tags: rake
 
 - name: create database if it doesn't exist
   command: bash -lc "bundle exec rake db:create RAILS_ENV={{ rails_env }}"


### PR DESCRIPTION
Closes #345

I've changed the order of a few of these tasks so that we don't get fatal error on a fresh install. 