### PR TITLE
Add --force flag to community modules update script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,4 +3,4 @@
 command -v ansible >/dev/null 2>&1 || { echo >&2 "I require ansible but it's not installed.  Aborting."; exit 1; }
 
 
-ansible-galaxy install -r bin/requirements.yml
+ansible-galaxy install -r bin/requirements.yml --force


### PR DESCRIPTION
The setup script installs our community modules but does not update them if the versions have been bumped. 

I've added this quick change as I think we'll need to update the community modules on various servers soon, including the local ansible installs of our staging servers that use Semaphore deployments, and it'll be much easier if this script actually works. :+1: 