### PR TITLE
Change languages in staging FR so we have english for english testers

### DIFF
--- a/inventory/host_vars/staging.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/staging.openfoodfrance.org/config.yml
@@ -7,4 +7,6 @@ admin_email: admin@openfoodfrance.org
 
 mail_domain: openfoodfrance.org
 
+available_locales: fr,en
+
 unicorn_timeout: 120


### PR DESCRIPTION
Changing languages in staging FR as per request from @RachL 
we will now have english in staging FR.

this is done in staging AUS [here](https://github.com/openfoodfoundation/ofn-install/blob/c55042af0cc313f27c16da9e664dd8babe5079b7/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml#L11).

But I tried to deploy this from my local ofn-install and although the application.yml file was rewritten with the deploy in /shared, the languages were not updated and remained the default fr, it specified in group_vars/fr.yml

I thought [this](https://github.com/openfoodfoundation/ofn-install/blob/c55042af0cc313f27c16da9e664dd8babe5079b7/roles/app/templates/application.yml.j2#L12) would pick up stuff from inventory_vars as well.