### PR TITLE
Set staging servers to update themselves

### DIFF
--- a/roles/semaphore_deployment/tasks/main.yml
+++ b/roles/semaphore_deployment/tasks/main.yml
@@ -19,6 +19,7 @@
     dest: "/home/{{ deployment_user }}/deploy"
     owner: root
     mode: 0700
+  tags: provision_deploy_script
 
 - name: add sudoers file
   template:

--- a/roles/semaphore_deployment/templates/deploy.j2
+++ b/roles/semaphore_deployment/templates/deploy.j2
@@ -15,4 +15,16 @@ fi
 
 cd "/home/{{ deployment_user }}/ofn-install"
 
+# Pull any recent ofn-install updates
+git pull
+
+# Update community roles if the requirements have changed
+if $(ansible-galaxy install -r bin/requirements.yml 2>&1 | grep -q "change version"); then
+    echo "Updating community roles..."
+    ansible-galaxy install -r bin/requirements.yml --force
+else
+    echo "All community roles are up to date"
+fi
+
+# Deploy
 ansible-playbook playbooks/deploy.yml --limit {{ ansible_limit }} --connection local -e "git_repo=https://github.com/openfoodfoundation/openfoodnetwork.git git_version=$branch @/home/ofn-admin/secrets.yml"


### PR DESCRIPTION
I havn't tracked my time for this as it's not been prioritised, it was a 5-minute job, but I think this could save a lot of time when we make important updates to ofn-install.

Staging servers that have Ansible installed locally for deploying themselves via Semaphore can now also update their local copy of ofn-install by pulling from the repo, and upgrade their community roles if the versions have been bumped in the `requirements.yml` file.