### PR TITLE
Improve community roles install task for Semaphore deployment

### DIFF
--- a/roles/semaphore_deployment/tasks/main.yml
+++ b/roles/semaphore_deployment/tasks/main.yml
@@ -34,7 +34,9 @@
   tags: fetch_ofn_install
 
 - name: install community modules
-  shell: "/home/{{ deployment_user }}/ofn-install/bin/setup"
+  shell: "bin/setup"
+  args:
+    chdir: "/home/{{ deployment_user }}/ofn-install/"
   tags: update_community_modules
 
 - name: create secure directory for keys


### PR DESCRIPTION
I've successfully run this task on staging servers without any problems, but I've had an error once or twice whilst testing this during the Bionic Beaver work, where the `bin/setup` script gave an error about the requirements file being missing.

This fixes the issue and should make it more consistent, by adding the `chdir` argument to the task to make sure ansible is in the `/ofn-install` folder when it runs the `bin/setup` script. 