### PR TITLE
Bionic beaver - take 2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 # Run the following command to set up this Vagrant box:
-# ansible-playbook site.yml -i inventory/dev --limit=vagrant
+# ansible-playbook site.yml --limit=vagrant
 
 # It takes around 20 minutes to complete the first setup/provision/deploy.
 # Your new local OFN instance will then be available at: http://localhost:8080
@@ -16,7 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   config.vm.provider :virtualbox do |vbox|
-    config.vm.box = "ubuntu/xenial64"
+    config.vm.box = "ubuntu/bionic64"
 
     # Set box memory.
     vbox.customize ["modifyvm", :id, "--memory", "1792"]

--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -3,7 +3,7 @@
   version: 1.5.0
 
 - src: zzet.rbenv
-  version: 3.0.0
+  version: 3.4.2
 
 - src: jdauphant.nginx
   version: v2.8.1

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -26,6 +26,9 @@
     - role: common # Install common apps and libraries, and setup shell.
       tags: common
 
+    - role: compatibility # Handle version-specific OS dependencies and configuration
+      tags: compatibility
+
     - role: language # Setup locale.
       tags: language
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -17,7 +17,6 @@
       - python-pycurl
       - python-psycopg2
       - python3-psycopg2
-      - python-software-properties
 
       # unknown why or if needed
       # The playbooks run without these dependencies,

--- a/roles/compatibility/tasks/main.yml
+++ b/roles/compatibility/tasks/main.yml
@@ -1,0 +1,25 @@
+--- # Compatibility
+
+- name: install packages for Ubuntu 16
+  apt:
+    name: "{{ xenial_packages }}"
+  become: yes
+  vars:
+    xenial_packages:
+      - python-software-properties
+  when: ansible_distribution_major_version == '16'
+
+- name: install packages for Ubuntu 18
+  apt:
+    name: "{{ bionic_packages }}"
+  become: yes
+  vars:
+    bionic_packages:
+      - software-properties-common
+  when: ansible_distribution_major_version == '18'
+
+- name: define additional rbenv build dependencies for Ruby 2.1.5 on Ubuntu 18
+  set_fact:
+    rbenv_extra_depends:
+      - libssl1.0-dev
+  when: ansible_distribution_major_version == '18'


### PR DESCRIPTION
Reverts openfoodfoundation/ofn-install#359

Closes #343
Closes #344

This pull request was initially opened by @Matt-Yorkley in #342. It was approved already.

This PR bring compatibility for Ubuntu 18 (Bionic Beaver) to ofn-install. I've tested the setup, provision, and deploy playbooks with these changes on both Ubuntu 16 and Ubuntu 18 boxes. Both are running fine, and the fatal errors are fixed for Ubuntu 18.

Additional notes are in the 2 issues above.

Note: this requires an update of the community roles with:
`ansible-galaxy install -r bin/requirements.yml --force`