### PR TITLE
Configure postgres for production

### DIFF
--- a/playbooks/postgres_tuning.yml
+++ b/playbooks/postgres_tuning.yml
@@ -31,6 +31,7 @@
           shared_buffers = {{ ( ansible_memtotal_mb / 4 ) | int }}MB
           effective_cache_size = {{ ( ( ansible_memtotal_mb / 4 ) * 3 ) | int }}MB
           maintenance_work_mem = {{ ( ansible_memtotal_mb / 16 ) | int }}MB
+          wal_buffers = 16MB
         dest: "/etc/postgresql/{{ pg_current_version.stdout }}/main/conf.d/tuning.conf"
       become: yes
       register: tuning_configuration

--- a/playbooks/postgres_tuning.yml
+++ b/playbooks/postgres_tuning.yml
@@ -32,6 +32,7 @@
           effective_cache_size = {{ ( ( ansible_memtotal_mb / 4 ) * 3 ) | int }}MB
           maintenance_work_mem = {{ ( ansible_memtotal_mb / 16 ) | int }}MB
           wal_buffers = 16MB
+          work_mem = 6MB
         dest: "/etc/postgresql/{{ pg_current_version.stdout }}/main/conf.d/tuning.conf"
       become: yes
       register: tuning_configuration

--- a/playbooks/postgres_tuning.yml
+++ b/playbooks/postgres_tuning.yml
@@ -1,0 +1,50 @@
+---
+- name: PostgreSQL production tuning
+  hosts: ofn_servers
+  remote_user: "{{ user }}"
+
+  tasks:
+    - name: Find current postgres version
+      shell: psql postgres -c 'SHOW config_file;' | grep etc | egrep -o '[0-9]{1,}\.*[0-9]{1,}'
+      become: yes
+      become_user: postgres
+      register: pg_current_version
+
+    - debug:
+        msg: "Postgres current version: {{ pg_current_version.stdout }}"
+
+    - name: Create postgres conf.d directory
+      file:
+        dest: "/etc/postgresql/{{ pg_current_version.stdout }}/main/conf.d"
+        state: directory
+      become: yes
+
+    - name: Include conf.d directory in postgresql.conf
+      lineinfile:
+        path: "/etc/postgresql/{{ pg_current_version.stdout }}/main/postgresql.conf"
+        line: "include_dir 'conf.d'"
+      become: yes
+
+    - name: Add tuning configuration
+      copy:
+        content: |
+          shared_buffers = {{ ( ansible_memtotal_mb / 4 ) | int }}MB
+          effective_cache_size = {{ ( ( ansible_memtotal_mb / 4 ) * 3 ) | int }}MB
+          maintenance_work_mem = {{ ( ansible_memtotal_mb / 16 ) | int }}MB
+        dest: "/etc/postgresql/{{ pg_current_version.stdout }}/main/conf.d/tuning.conf"
+      become: yes
+      register: tuning_configuration
+      when: remove_postgres_tuning is undefined
+
+    - name: Optionally remove tuning configuration
+      file:
+        path: "/etc/postgresql/{{ pg_current_version.stdout }}/main/conf.d/tuning.conf"
+        state: absent
+      when: remove_postgres_tuning is defined
+
+    - name: Reload postgres
+      service:
+        name: postgresql
+        state: reloaded
+      become: yes
+      when: tuning_configuration.changed

--- a/playbooks/postgres_tuning.yml
+++ b/playbooks/postgres_tuning.yml
@@ -4,24 +4,20 @@
   remote_user: "{{ user }}"
 
   tasks:
-    - name: Find current postgres version
-      shell: psql postgres -c 'SHOW config_file;' | grep etc | egrep -o '[0-9]{1,}\.*[0-9]{1,}'
-      become: yes
-      become_user: postgres
-      register: pg_current_version
-
-    - debug:
-        msg: "Postgres current version: {{ pg_current_version.stdout }}"
+    - name: Gather postgres installation details
+      include_role:
+        name: geerlingguy.postgresql
+        tasks_from: variables
 
     - name: Create postgres conf.d directory
       file:
-        dest: "/etc/postgresql/{{ pg_current_version.stdout }}/main/conf.d"
+        dest: "{{ postgresql_config_path }}/conf.d"
         state: directory
       become: yes
 
-    - name: Include conf.d directory in postgresql.conf
+    - name: Enable conf.d directory
       lineinfile:
-        path: "/etc/postgresql/{{ pg_current_version.stdout }}/main/postgresql.conf"
+        path: "{{ postgresql_config_path }}/postgresql.conf"
         line: "include_dir 'conf.d'"
       become: yes
 
@@ -33,14 +29,14 @@
           maintenance_work_mem = {{ ( ansible_memtotal_mb / 16 ) | int }}MB
           wal_buffers = 16MB
           work_mem = 6MB
-        dest: "/etc/postgresql/{{ pg_current_version.stdout }}/main/conf.d/tuning.conf"
+        dest: "{{ postgresql_config_path }}/conf.d/tuning.conf"
       become: yes
       register: tuning_configuration
       when: remove_postgres_tuning is undefined
 
     - name: Optionally remove tuning configuration
       file:
-        path: "/etc/postgresql/{{ pg_current_version.stdout }}/main/conf.d/tuning.conf"
+        path: "{{ postgresql_config_path }}/conf.d/tuning.conf"
         state: absent
       when: remove_postgres_tuning is defined
 


### PR DESCRIPTION
Closes #361 

This is a draft playbook to configure PostgreSQL for production servers by setting some recommended values.

It might be a good idea to get the Datadog paid plan first, as discussed here: https://community.openfoodnetwork.org/t/making-operations-a-first-class-citizen/1601/5

Then we could try provisioning this configuration to one production server and get some data on the results.