### PR TITLE
Rescue and notify Slack when deployment fails

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -5,5 +5,16 @@
   become: yes
   become_user: "{{ unicorn_user }}"
 
-  roles:
-    - role: deploy
+  tasks:
+    - block:
+      - include_role:
+          name: deploy
+
+      rescue:
+        - name: Notify slack of deployment failure
+          slack:
+            token: "T02G54U79/BF25P9F7A/DJdtYaLLUpRJPiu72d8NqgGg"
+            msg: 'Deployment FAILED for {{ inventory_hostname }}'
+            channel: "#devops-notifications"
+            username: "ansible executed by {{ lookup('env','USER') }}"
+          when: inventory_hostname != "local_vagrant"

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -10,6 +10,16 @@
       - include_role:
           name: deploy
 
+      - meta: flush_handlers # Ensure handlers run successfully before reporting success
+
+      - name: Notify Slack of successful deployment
+        slack:
+          token: "T02G54U79/BF25P9F7A/DJdtYaLLUpRJPiu72d8NqgGg"
+          msg: '`{{ git_version }}` deployed to {{ inventory_hostname }}'
+          channel: "#devops-notifications"
+          username: "ansible executed by {{ lookup('env','USER') }}"
+        when: inventory_hostname != "local_vagrant"
+
       rescue:
         - name: Notify slack of deployment failure
           slack:

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -57,11 +57,3 @@
   command: bash -lc "bundle exec whenever --set 'environment={{ rails_env }}' --update-crontab"
   args:
     chdir: "{{ current_path }}"
-
-- name: notify slack
-  slack:
-    token: "T02G54U79/BF25P9F7A/DJdtYaLLUpRJPiu72d8NqgGg"
-    msg: '`{{ git_version }}` deployed to {{ inventory_hostname }}'
-    channel: "#devops-notifications"
-    username: "ansible executed by {{ lookup('env','USER') }}"
-  when: inventory_hostname != "local_vagrant"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -207,4 +207,3 @@
     - restart unicorn
     - restart delayed job service
     - update whenever
-    - notify slack


### PR DESCRIPTION
We can now get notified when deployment fails as well as when it succeeds, using Ansible's block/rescue format in the `deployment.yml` playbook.

Tested on Vagrant (both success and failure paths).