### PR TITLE
Check secrets have been included

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -5,5 +5,9 @@
   become: yes
   become_user: "{{ unicorn_user }}"
 
+  pre_tasks:
+    - include_role:
+        name: check_secrets
+
   roles:
     - role: deploy

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -6,6 +6,10 @@
   vars:
     nginx_daemon_mode: off
 
+  pre_tasks:
+    - include_role:
+        name: check_secrets
+
   roles:
     - role: ssh_keys # Add sysadmin ssh keys to server
       become: yes

--- a/roles/check_secrets/tasks/main.yml
+++ b/roles/check_secrets/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Check secrets
   fail:
-    msg: "ERROR: It looks like your secrets.yml file is missing..."
+    msg: "ERROR: It looks like your secrets.yml file is missing. You can add them by providing the argument: `-e @path/to/secrets.yml`"
   when: db_password is undefined or secret_token is undefined

--- a/roles/check_secrets/tasks/main.yml
+++ b/roles/check_secrets/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Check secrets
+  fail:
+    msg: "ERROR: It looks like your secrets.yml file is missing..."
+  when: db_password is undefined or secret_token is undefined


### PR DESCRIPTION
Closes #365 

Provision and deploy playbooks will now exit early if the secrets have not been included correctly.

Tested (both paths) on Vagrant.