### PR TITLE
Fetch secrets when deploying with Semaphore

### DIFF
--- a/playbooks/setup_semaphore_deployment.yml
+++ b/playbooks/setup_semaphore_deployment.yml
@@ -4,5 +4,10 @@
   remote_user: "{{ user }}"
   become: yes
 
+  vars_prompt:
+    - name: ofn_vault_pass
+      prompt: "Set vault password (or enter to skip)"
+      private: yes
+
   roles:
     - role: semaphore_deployment

--- a/roles/semaphore_deployment/tasks/main.yml
+++ b/roles/semaphore_deployment/tasks/main.yml
@@ -53,6 +53,7 @@
 - name: copy public key
   shell: "cat /home/{{ user }}/keys/semaphore.pub"
   register: semaphore_public_key
+  changed_when: False
 
 - name: add semaphore public key to deployment user's authorized_keys
   authorized_key:

--- a/roles/semaphore_deployment/tasks/main.yml
+++ b/roles/semaphore_deployment/tasks/main.yml
@@ -61,3 +61,12 @@
     key: "{{ semaphore_public_key.stdout }}"
     state: present
     key_options: 'restrict,command="sudo /home/{{ deployment_user }}/deploy \"$SSH_ORIGINAL_COMMAND\""'
+
+- name: write vault password
+  copy:
+    content: "{{ ofn_vault_pass }}"
+    dest: "/home/{{ user }}/keys/vault-pass"
+    owner: root
+    mode: 0600
+  become: yes
+  when: ofn_vault_pass is defined and ofn_vault_pass | length > 0

--- a/roles/semaphore_deployment/templates/deploy.j2
+++ b/roles/semaphore_deployment/templates/deploy.j2
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 set -e
-branch="$1"
+
+# Parse input
+arguments=($1)
+branch="${arguments[0]}"
+secret_repo="${arguments[1]}"
+
 allowed=^[a-zA-Z0-9._/\-]+$
 
 # Given branch name must be a single string with no spaces,
@@ -27,6 +32,13 @@ if $(ansible-galaxy install -r bin/requirements.yml 2>&1 | grep -q "change versi
     ansible-galaxy install -r bin/requirements.yml --force
 else
     echo "### All community roles are up to date."
+fi
+
+# Optionally fetch latest secrets
+if [ -n "$secret_repo" ] && [ -f /home/ofn-admin/keys/vault-pass ]; then
+    echo '### Fetching secrets...'
+    curl "$secret_repo"/master/uk-staging/secrets.yml > /home/ofn-admin/secrets.yml
+    ansible-vault decrypt --vault-password-file /home/ofn-admin/keys/vault-pass /home/ofn-admin/secrets.yml
 fi
 
 # Deploy

--- a/roles/semaphore_deployment/templates/deploy.j2
+++ b/roles/semaphore_deployment/templates/deploy.j2
@@ -16,14 +16,17 @@ fi
 cd "/home/{{ deployment_user }}/ofn-install"
 
 # Pull any recent ofn-install updates
+echo "### Updating local ofn-install files..."
 git pull
 
 # Update community roles if the requirements have changed
+echo "### Checking community roles..."
+
 if $(ansible-galaxy install -r bin/requirements.yml 2>&1 | grep -q "change version"); then
-    echo "Updating community roles..."
+    echo "### Updating community roles..."
     ansible-galaxy install -r bin/requirements.yml --force
 else
-    echo "All community roles are up to date"
+    echo "### All community roles are up to date."
 fi
 
 # Deploy


### PR DESCRIPTION
This is a proposal to modify the Semaphore deployment system so that a server will automatically fetch the latest copy of it's own secrets file from the new private repo when it's deploying itself.

There's a couple of contentious bits:
- we provision the vault password into a file under `/home/ofn-admin/`, owned by `root` with 600 permissions as a one-off event when the `setup_semaphore_deployment.yml` is run against the server we're setting up. It's handled via a secure prompt, so the sysadmin provisioning it has to manually put in the password.
- in order to pull from the private repo we use a bot account, give it read access on the secrets repo, and create a Personal Access Token in the bot's account which gives access to read files in that repo and nothing else. We can then use that token programmatically to pull from the secrets repo.
- we save that token into Semaphore, using an encrypted environment variable in the Semaphore secrets UI. The secret can't be read or edited by any Semaphore users after that point (it can be deleted). We then pass it to the server that's being deployed so it can fetch the (encrypted) secrets and decrypt them with the vault-pass file.

Simple, right? :trollface: 
