### PR TITLE
Remove db2fog initializer from ofn-install

### DIFF
--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -40,17 +40,6 @@
     path: "{{ config_path }}/bugsnag.rb"
     state: absent
 
-- name: copy the db2fog file into the shared folder
-  template:
-    src: db2fog.rb.j2
-    dest: "{{ config_path }}/db2fog.rb"
-    owner: "{{ unicorn_user }}"
-    mode: 0775
-  tags:
-    - app_templates
-    - db2fog
-  when: s3_backups_bucket is defined
-
 - name: get l10n repo
   git:
     repo={{ l10n_repo }}

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -19,7 +19,7 @@ CHECKOUT_ZONE: {{ checkout_zone }}
 GOOGLE_MAPS_API_KEY: {{ google_maps_api_key }}
 
 {% if s3_backups_bucket is defined %}
-S3_BACKUPS_BUCKET: {{ s3_backups_bucket }}
+S3_BUCKET: {{ s3_backups_bucket }}
 S3_ACCESS_KEY: {{ s3_access_key }}
 S3_SECRET: {{ s3_secret }}
 {% endif %}

--- a/roles/app/templates/db2fog.rb.j2
+++ b/roles/app/templates/db2fog.rb.j2
@@ -1,7 +1,0 @@
-# See: https://github.com/yob/db2fog
-DB2Fog.config = {
-  :aws_access_key_id     => Spree::Config[:s3_access_key],
-  :aws_secret_access_key => Spree::Config[:s3_secret],
-  :directory             => "{{ s3_backups_bucket }}",
-  :provider              => 'AWS'
-}

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -57,17 +57,6 @@
     - { src: "{{ config_path }}/post-receive", dest: "{{ build_path }}/.git/hooks/post-receive" }
   tags: symlink
 
-- name: symlink the db2fog file into the config folder
-  file:
-    src="{{ config_path }}/db2fog.rb"
-    dest={{ build_path }}/config/initializers/db2fog.rb
-    state=link
-    force=yes
-    owner={{ unicorn_user }}
-    mode=0775
-  when: s3_backups_bucket is defined
-  tags: symlink
-
 - name: install bundler
   # This needs to be run inside a bash shell to initialise rbenv
   # See http://stackoverflow.com/questions/22115936/install-bundler-gem-using-ansible


### PR DESCRIPTION
Closes #280 

Removes the db2fog initializer from ofn-install after it is moved to the main repo in: https://github.com/openfoodfoundation/openfoodnetwork/pull/3694

This also frees up the `deploy.yml` playbook from all dependencies on secrets files, so deploying from the command line will be much simpler and deploying via Semaphore will not involve any secrets handling. :tada: 

#### Dependencies

openfoodfoundation/openfoodnetwork#3694