### PR TITLE
Use latest ansible in semaphore deployment

### DIFF
--- a/roles/semaphore_deployment/tasks/main.yml
+++ b/roles/semaphore_deployment/tasks/main.yml
@@ -1,8 +1,15 @@
 --- # Set up Ansible and restricted deployment user for deployment via Semaphore
 
+- name: add ansible ppa
+  apt_repository:
+    repo: ppa:ansible/ansible
+  become: yes
+
 - name: install ansible
   apt:
+    update_cache: yes
     name: ansible
+    state: latest
   become: yes
 
 - name: create deployment user


### PR DESCRIPTION
We hit an issue today with a staging server not recognising Ansible syntax because the version it had was incredibly old. This switches to using the latest version from the Ansible repo.

To update it, just run the `setup_semaphore_deployment.yml` playbook against any server that uses Semaphore.

@sauloperez 