### PR TITLE
Do not check secrets as a requirement to deploy

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -5,9 +5,5 @@
   become: yes
   become_user: "{{ unicorn_user }}"
 
-  pre_tasks:
-    - include_role:
-        name: check_secrets
-
   roles:
     - role: deploy


### PR DESCRIPTION
Closes #371

As explained in https://github.com/openfoodfoundation/ofn-install/issues/371 we no longer need secrets while deploying so there is no need for this check anymore :tada:.

This should fix the last Semaphore deployment failure https://semaphoreci.com/openfoodfoundation/openfoodnetwork-2/servers/fr-staging/deploys/8.