### PR TITLE
Specify depth when fetching repo

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -28,6 +28,7 @@
     dest: "{{ build_path }}"
     version: "{{ git_version }}"
     refspec: "+refs/pull/*/merge:refs/remotes/origin/pull-request-*"
+    depth: 1
     force: yes
   tags: clone
 


### PR DESCRIPTION
This is equivalent to `--depth 1`, meaning we fetch only the latest version of each file and not the entire history. 

It reduces the execution time of this task from ~2:30 to ~0:40. :rocket: 