### PR TITLE
Allow provisioning of different buckets

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -17,10 +17,11 @@ secret_token: 'xxxxxx'
 # Create a Google Maps API key and enable Javascript and Places libraries
 google_maps_api_key:
 
-# Set these if using Amazon S3 backups with db2fog
-#s3_backups_bucket:
+# Set these if using Amazon S3
 #s3_access_key:
 #s3_secret:
+#s3_images_bucket:
+#s3_backups_bucket:
 
 # Stripe Connect API keys
 # Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -18,10 +18,17 @@ CHECKOUT_ZONE: {{ checkout_zone }}
 
 GOOGLE_MAPS_API_KEY: {{ google_maps_api_key }}
 
-{% if s3_backups_bucket is defined %}
-S3_BUCKET: {{ s3_backups_bucket }}
+{% if s3_access_key is defined %}
 S3_ACCESS_KEY: {{ s3_access_key }}
+{% endif %}
+{% if s3_secret is defined %}
 S3_SECRET: {{ s3_secret }}
+{% endif %}
+{% if s3_backups_bucket is defined %}
+S3_BACKUPS_BUCKET: {{ s3_backups_bucket }}
+{% endif %}
+{% if s3_images_bucket is defined %}
+S3_BUCKET: {{ s3_images_bucket }}
 {% endif %}
 
 STRIPE_CLIENT_ID: {{ stripe_client_id }}


### PR DESCRIPTION
This allows for provisioning of different buckets for images and backups, and enables provisioning of the `Spree::Config['s3_bucket']` preference used for images, which was previously only accessible via the superadmin config page.

This is a partial patch for recent changes in #370 

**Configuration:**
The use of `s3_backups_bucket` variable is unchanged.
The new `s3_images_bucket` will populate the `Spree::Config[:s3_bucket]` preference which is used for images. Unless that variable is explicitly set in the secrets file, no existing manually configured settings will be changed.