### PR TITLE
Remove already provisioned Bugsnag absence check

### DIFF
--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -35,11 +35,6 @@
     - { src: "seed.sh.j2", dest: "{{ config_path }}/seed.sh" }
   tags: app_templates
 
-- name: remove bugsnag's initializer from the shared folder
-  file:
-    path: "{{ config_path }}/bugsnag.rb"
-    state: absent
-
 - name: get l10n repo
   git:
     repo={{ l10n_repo }}


### PR DESCRIPTION
Closes #332

Added in https://github.com/openfoodfoundation/ofn-install/pull/329, it was meant to ensure said file gets removed from our servers. Merged back on Feb 28, all these servers have been provisioned and so UK, FR, Katuma, BE and DE servers do not have the file anymore. I checked it manually so we can remove it.