### PR TITLE
Change LXC's domain to a local one

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -5,7 +5,7 @@
 local_vagrant ansible_host=127.0.0.1 ansible_user=vagrant ansible_port=2222 ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 
 [lxc]
-local.ofn.org
+ofn.local
 
 [local:children]
 vagrant


### PR DESCRIPTION
I came across this while setting up a LXC container to work on some refactoring as it will speed up a lot my development process. The issue is as follows.

Firstly, I used https://github.com/coopdevs/devenv to set up the
container and I specified local.ofn.org as its domain.

Then, when I running the `playbooks/setup.yml` I got:

```
fatal: [local.ofn.org]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: root@local.ofn.org: Permission denied (publickey).", "unreachable": true}
```

However, when issuing a `ssh root@10.0.3.57` I could successfully log in. To my surprise, when I typed local.ofn.org on a browser, I got an Apache web server default page. Then, navigating to ofn.org returned the home page of Opportunity Finance Network :joy:.

Something to note here is that Linux's behavior is to first use the DNS server specified in `/etc/resolv.conf/` to resolve any name, just then the fallback is `/etc/hosts`.

So, if we want our LXC domain not to conflict with any other site, it's better to use something which is not a top-level domain like `local`.