### PR TITLE
Create europe group

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -126,6 +126,16 @@ www.openfoodnetwork.be ansible_host=51.75.124.147
 be-prod
 
 #------------------------------------------------------------------------------
+# Europe
+
+[europe:children]
+be-prod
+es-prod
+fr-prod
+uk-prod
+#de-prod
+
+#------------------------------------------------------------------------------
 # All
 
 [ofn_servers:children]


### PR DESCRIPTION
Closes #313 

Adds a `europe` group in the hosts file, so playbooks can be run against multiple servers at once.

Hot tip: you can test which servers would be included in a command by using `--limit europe` and `--list-hosts`.