### PR TITLE
Revert use of --depth

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -28,7 +28,6 @@
     dest: "{{ build_path }}"
     version: "{{ git_version }}"
     refspec: "+refs/pull/*/merge:refs/remotes/origin/pull-request-*"
-    depth: 1
     force: yes
   tags: clone
 


### PR DESCRIPTION
The Ansible git module doesn't play nicely with combining a custom refspec (which we need for accessing pull requests in Semaphore deployment) and the `--depth` flag, so we need to revert this and lose the speed increase.