### PR TITLE
Update unicorn reload handler

### DIFF
--- a/roles/webserver/handlers/main.yml
+++ b/roles/webserver/handlers/main.yml
@@ -1,8 +1,8 @@
-- name: reload unicorn
+- name: check service status
   service_facts:
-  notify: reload unicorn if running
+  listen: reload unicorn
 
-- name: reload unicorn if running
+- name: reload unicorn
   service:
     name: unicorn_{{ app }}
     state: reloaded

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -25,6 +25,7 @@
     owner: "{{ unicorn_user }}"
     group: "{{ unicorn_user }}"
   become: yes
+  tags: unicorn_config
   notify: reload unicorn
 
 - name: Reload systemd


### PR DESCRIPTION
While testing the new reload handler for reloading when the unicorn config file is updated, I realised we needed an extra step to avoid a fatal error when trying to reload before the service had been started on a fresh install.

The two-step handler I created to fix it wasn't correctly triggering the second step, so the error was fixed but the reload was not being triggered properly. It's fixed now.