### PR TITLE
Set num. of Unicorn workers to 4 for FR production

### DIFF
--- a/inventory/host_vars/www.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/www.openfoodfrance.org/config.yml
@@ -8,6 +8,7 @@ admin_email: admin@openfoodfrance.org
 mail_domain: openfoodfrance.org
 
 unicorn_timeout: 120
+unicorn_workers: 4
 
 postgres_listen_addresses:
   - '*'


### PR DESCRIPTION
Closes #395

Having 8 Gb of RAM there's plenty of room for increased concurrency. OFF's users will appreciate it.

Also, having a Datadog pro account we can closely watch the impact of this change on the system resources.