### PR TITLE
Enable pg stat statements

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -79,6 +79,12 @@ postgres_listen_addresses:
 postgresql_global_config_options:
   - option: listen_addresses
     value: "{{ postgres_listen_addresses | join(',') }}"
+  - option: shared_preload_libraries
+    value: 'pg_stat_statements'
+  - option: pg_stat_statements.track
+    value: all
+  - option: pg_stat_statements.max
+    value: 10000
 
 
 #----------------------------------------------------------------------

--- a/playbooks/development.yml
+++ b/playbooks/development.yml
@@ -33,6 +33,8 @@
       tags: ruby
 
     - role: dbserver # Set up database server and user for the app.
+      become: yes
+      become_user: root
       tags: dbserver
       db_user_roles: SUPERUSER,CREATEDB
 

--- a/roles/dbserver/tasks/main.yml
+++ b/roles/dbserver/tasks/main.yml
@@ -1,6 +1,6 @@
 --- # dbserver
 
-- import_tasks: postgresql.yml
+- import_tasks: postgresql.yml # Install postgresql with geerlingguy.postgresql role
 
 - name: add .pgpass file for {{ unicorn_user }}
   template:
@@ -13,3 +13,10 @@
 
 - import_tasks: fix_template_encoding.yml
   tags: template_encoding
+
+- name: create extensions
+  become: yes
+  become_user: postgres
+  postgresql_ext:
+    name: pg_stat_statements
+    db: "{{ db }}"

--- a/roles/dbserver/tasks/postgresql.yml
+++ b/roles/dbserver/tasks/postgresql.yml
@@ -14,14 +14,6 @@
 - include_role:
     name: geerlingguy.postgresql
     tasks_from: configure
-  vars:
-    postgresql_global_config_options:
-      - option: shared_preload_libraries
-        value: 'pg_stat_statements'
-      - option: pg_stat_statements.track
-        value: all
-      - option: pg_stat_statements.max
-        value: 10000
 
 - name: create extensions
   become: yes

--- a/roles/dbserver/tasks/postgresql.yml
+++ b/roles/dbserver/tasks/postgresql.yml
@@ -14,6 +14,21 @@
 - include_role:
     name: geerlingguy.postgresql
     tasks_from: configure
+  vars:
+    postgresql_global_config_options:
+      - option: shared_preload_libraries
+        value: 'pg_stat_statements'
+      - option: pg_stat_statements.track
+        value: all
+      - option: pg_stat_statements.max
+        value: 10000
+
+- name: create extensions
+  become: yes
+  become_user: postgres
+  postgresql_ext:
+    name: pg_stat_statements
+    db: "{{ db }}"
 
 - include_role:
     name: geerlingguy.postgresql

--- a/roles/dbserver/tasks/postgresql.yml
+++ b/roles/dbserver/tasks/postgresql.yml
@@ -15,13 +15,6 @@
     name: geerlingguy.postgresql
     tasks_from: configure
 
-- name: create extensions
-  become: yes
-  become_user: postgres
-  postgresql_ext:
-    name: pg_stat_statements
-    db: "{{ db }}"
-
 - include_role:
     name: geerlingguy.postgresql
     tasks_from: users


### PR DESCRIPTION
## Description

Closes #375 

> The pg_stat_statements module provides a means for tracking execution statistics of all SQL statements executed by a server. Source https://www.postgresql.org/docs/9.5/pgstatstatements.html

I chose to use the parameters showed at PostgreSQL docs in the "Configuration Parameters" section to start with.

It contains tons of useful aggregate data about the statements the DB runs. See the result of placing an order:

```sql
open_food_network_dev= SELECT query, calls, total_time, rows, 100.0 * shared_blks_hit /
               nullif(shared_blks_hit + shared_blks_read, 0) AS hit_percent
          FROM pg_stat_statements WHERE query not like '%pg_stat_%' ORDER BY total_time DESC LIMIT 5;
(...)
-[ RECORD 2 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
query       | INSERT INTO "sessions" ("created_at", "data", "session_id", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"
calls       | 5
total_time  | 83.215
rows        | 5
hit_percent | 73.5294117647058824
(...)
-[ RECORD 4 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
query       | SELECT "spree_tax_categories".* FROM "spree_tax_categories"  WHERE "spree_tax_categories"."deleted_at" IS NULL ORDER BY name
calls       | 1
total_time  | 57.945
rows        | 1
hit_percent | 0.00000000000000000000
-[ RECORD 5 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
query       | SELECT "spree_option_values".* FROM "spree_option_values" INNER JOIN "spree_option_types" ON "spree_option_types"."id" = "spree_option_values"."option_type_id" INNER JOIN "spree_option_values_variants" ON "spree_option_values"."id" = "spree_option_values_variants"."option_value_id" WHERE "spree_option_values_variants"."variant_id" = ? ORDER BY spree_option_types.position asc
calls       | 18
total_time  | 37.86
rows        | 18
hit_percent | 92.2222222222222222
```

## Will this be enabled in all instances?

Yep. Reasons: 

1) I don't see why we can't treat all servers as production, meaning, logging, metrics, etc. enabled
2) this is needed to troubleshoot issues and they will happen in all instances, regardless of their size
3) the fewer conditionals everywhere the better