### PR TITLE
Enable capturing of PostgreSQL's stderr

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -85,6 +85,22 @@ postgresql_global_config_options:
     value: all
   - option: pg_stat_statements.max
     value: 10000
+  - option: log_destination
+    value: 'stderr'
+  - option: logging_collector
+    value: on
+  - option: log_directory
+    value: 'pg_log'
+  - option: log_filename
+    value: 'postgresql-%Y-%m-%d_%H%M%S.log'
+  - option: log_file_mode
+    value: 0600
+  - option: log_truncate_on_rotation
+    value: on
+  - option: log_rotation_age
+    value: 131490 # 3 months
+  - option: log_statement
+    value: 'all'
 
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
Closes #379

This will help diagnose the execution of the DB server. You know, you
better have a log file at hand when things go south...

It sends log messages to files like `postgresql-2019-04-19_183500.log`
in `/var/lib/postgresql/9.5/main/pg_log`. These per-day log files will
get overwritten on rotation, keeping a 3-month window always. Yes, it
turns out PostgrSQL has a built-in log rotation facility :muscle:.

I chose 3 months out of nothing. We need to see how fast the disk fills
up and adjust the value. I thought 3 months is more than enough data to
troubleshoot issues.

I also went with the default `pg_log` directory but it might be
interesting to log it to `/var/log/` in the future instead. According to
https://logdna.com/postgresql-logging-guide/:

> set this parameter to a value other than pg_log or log under the
> installation directory. Here is why:

> If you need to recreate the PostgreSQL installation for some reason
> (for example when you are re-creating replication), the logging folder
> will be deleted from the installation directory and you will lose all
> events from the old instance. It will be impossible to go back to track
> any events or errors from that instance.

> Security and legal compliance may require retaining logs for a long
> period of time (in some cases it can be up to ten years) and the volume
> hosting the Postgres directory may not have enough space for that. You
> can create the logging directory say, under /var/log and mount it to
> a separate file system.

Something to be aware of though is that statements that contain simple
syntax errors won't be logged even with `log_statement = all`.

**Note this PR depends on #409 which makes use of `postgresql_global_config_options`**