### PR TITLE
Ensure correct exit code on deployment

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -31,3 +31,7 @@
             channel: "#devops-notifications"
             username: "ansible executed by {{ lookup('env','USER') }}"
           when: inventory_hostname != "local_vagrant"
+
+        - debug:
+            msg: Deployment failed
+          failed_when: True # Ensure Ansible returns a non-zero error code after rescue


### PR DESCRIPTION
We hit this issue the other day when Rachel was testing. It turns out the rescue block we use in deploy.yml to send a failed deployment alert to Slack interferes with the exit code of the playbook because of an Ansible bug. This fixes it.

See Ansible issue for more details: https://github.com/ansible/ansible/issues/48344