### PR TITLE
Clean up db:seed task

### DIFF
--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -31,7 +31,6 @@
   with_items:
     - { src: "application.yml.j2", dest: "{{ config_path }}/application.yml" }
     - { src: "postgresql.yml.j2", dest: "{{ config_path }}/database.yml" }
-    - { src: "seed.sh.j2", dest: "{{ config_path }}/seed.sh" }
   tags: app_templates
 
 - name: get l10n repo

--- a/roles/app/templates/seed.sh.j2
+++ b/roles/app/templates/seed.sh.j2
@@ -1,7 +1,0 @@
-#!/bin/bash
-# This script automates the otherwise interactive db:seed rake task
-
-bundle exec rake db:seed <<EOF
-{{ admin_email }}
-{{ admin_password }}
-EOF

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -96,11 +96,9 @@
     - restart unicorn
 
 - name: seed database
-  # We run a shell script that passes the default email and password to rake with an EOF block, so we don't hang on the prompts.
-  command: bash -lc "{{ config_path }}/seed.sh RAILS_ENV={{ rails_env }}"
+  command: bash -lc "bundle exec rake db:seed RAILS_ENV={{ rails_env }} ADMIN_EMAIL={{ admin_email }} ADMIN_PASSWORD={{ admin_password }}"
   args:
     chdir: "{{ current_path }}"
-  # when: table_exists.stderr.find('does not exist') != -1
   tags:
     - seed
     - skip_ansible_lint


### PR DESCRIPTION
Follow-up from: https://github.com/openfoodfoundation/ofn-install/pull/415#discussion_r277547914

We don't need tasks in multiple playbooks to get this job done :+1: 

The code that handles this rake task is in the `spree_auth_devise` gem, and it either takes input from `ENV` vars, or prompts for user input (which then hangs in Ansible).