### PR TITLE
Lint!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,7 @@ script:
   - bin/setup
   - |
     if [ "${task}" == "LINT" ]; then
-      ansible-playbook -i inventory/dev --syntax-check site.yml
-      ansible-playbook -i inventory/dev --syntax-check playbooks/backup.yml
-      ansible-playbook -i inventory/dev --syntax-check playbooks/deploy.yml
-      ansible-playbook -i inventory/dev --syntax-check playbooks/provision.yml
-      ansible-playbook -i inventory/dev --syntax-check playbooks/rollback.yml
-      ansible-playbook -i inventory/dev --syntax-check playbooks/setup.yml
-      ansible-playbook -i inventory/dev --syntax-check playbooks/development.yml
-      ansible-lint site.yml --exclude=community
+      ansible-lint playbooks/*.yml --exclude community
     fi
   - |
     if [ "${task}" == "BUILD" ]; then

--- a/playbooks/db_integrations.yml
+++ b/playbooks/db_integrations.yml
@@ -7,9 +7,11 @@
   hosts: ofn_servers
   remote_user: "{{ user }}"
   become: yes
+  vars:
+    postgresql_restarted_state: "restarted"
 
   handlers:
-    - include: geerlingguy.postgresql/handlers/main.yml
+    - include: ../community/geerlingguy.postgresql/handlers/main.yml
 
   pre_tasks:
     - include_role:

--- a/playbooks/postgres_tuning.yml
+++ b/playbooks/postgres_tuning.yml
@@ -31,7 +31,7 @@
           work_mem = 6MB
         dest: "{{ postgresql_config_path }}/conf.d/tuning.conf"
       become: yes
-      register: tuning_configuration
+      notify: reload postgres
       when: remove_postgres_tuning is undefined
 
     - name: Optionally remove tuning configuration
@@ -40,9 +40,9 @@
         state: absent
       when: remove_postgres_tuning is defined
 
-    - name: Reload postgres
+  handlers:
+    - name: reload postgres
       service:
         name: postgresql
         state: reloaded
       become: yes
-      when: tuning_configuration.changed

--- a/playbooks/restore_backup.yml
+++ b/playbooks/restore_backup.yml
@@ -4,7 +4,7 @@
   remote_user: "{{ unicorn_user }}"
 
   tasks:
-    - name: restore backup
+    - name: restore backup # noqa 301
       command: "{{ bundle_path }} exec rake db2fog:restore"
       args:
         chdir: "{{ current_path }}"

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -6,7 +6,9 @@
 - name: get current date for timestamp
   shell: date +"%Y-%m-%d-%I%M%S"
   register: current_date
-  tags: backup
+  tags:
+    - backup
+    - skip_ansible_lint
 
 #-----------------
 # Backup and fetch
@@ -17,6 +19,7 @@
   shell: pg_dump -h {{ db_host }} -U {{ db_user }} {{ db }} | gzip > {{ backup_path }}/{{ backup_filename }}
   become: yes
   become_user: "{{ unicorn_user }}"
+  tags: skip_ansible_lint
 
 - name: fetch database to local
   fetch:

--- a/roles/db_integrations/tasks/main.yml
+++ b/roles/db_integrations/tasks/main.yml
@@ -14,7 +14,7 @@
   when: db_integration.state == 'present'
   register: integration_config
 
-- name: Grant permissions
+- name: Grant permissions # noqa 503
   become: yes
   become_user: postgres
   command: "psql {{ db }} -c '{{ permission_query }}'"

--- a/roles/rollback/tasks/main.yml
+++ b/roles/rollback/tasks/main.yml
@@ -10,8 +10,10 @@
   args:
     creates: "{{ current_path }}"
 
-- name: close active db connections
-  shell: psql -c "REVOKE CONNECT ON DATABASE {{ db }} FROM public; SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='{{ db }}' AND pid <> pg_backend_pid();"
+- name: close active db connections # noqa 301
+  shell: |
+    psql -c "REVOKE CONNECT ON DATABASE {{ db }} FROM public;
+    SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='{{ db }}' AND pid <> pg_backend_pid();"
   become: true
   become_user: postgres
 

--- a/roles/semaphore_deployment/tasks/main.yml
+++ b/roles/semaphore_deployment/tasks/main.yml
@@ -5,7 +5,7 @@
     repo: ppa:ansible/ansible
   become: yes
 
-- name: install ansible
+- name: install ansible # noqa 403
   apt:
     update_cache: yes
     name: ansible
@@ -54,13 +54,14 @@
     creates: "/home/{{ user }}/keys/semaphore.pub"
 
 - name: copy public key
-  shell: "cat /home/{{ user }}/keys/semaphore.pub"
+  slurp:
+    src: "/home/{{ user }}/keys/semaphore.pub"
   register: semaphore_public_key
   changed_when: False
 
 - name: add semaphore public key to deployment user's authorized_keys
   authorized_key:
     user: "{{ deployment_user }}"
-    key: "{{ semaphore_public_key.stdout }}"
+    key: "{{ semaphore_public_key.content | b64decode }}"
     state: present
     key_options: 'restrict,command="sudo /home/{{ deployment_user }}/deploy \"$SSH_ORIGINAL_COMMAND\""'


### PR DESCRIPTION
This PR includes:
- Applying linter rules properly to the codebase!
- Fixing new lint errors

I discovered we haven't been using `ansible-lint` properly in travis, so I updated it. There were a bunch of new warnings when I applied the rules, so I reviewed and addressed them. Some are fixed, and some are ignored with the preferred syntax here: https://github.com/ansible/ansible-lint#false-positives-skipping-rules

I used `skip_ansible_lint` in the `backup.yml` playbook because I'm not sure we even use it, and it could maybe just be deleted.

Errors fixed:
```
WARNING: Couldn't open /home/user/Github/ofn-install/playbooks/geerlingguy.postgresql/handlers/main.yml - No such file or directory

[301] Commands should not change things if nothing needs doing
/home/user/Github/ofn-install/roles/backup/tasks/main.yml:6
Task/Handler: get current date for timestamp

[305] Use shell only when shell functionality is required
/home/user/Github/ofn-install/roles/backup/tasks/main.yml:6
Task/Handler: get current date for timestamp

[301] Commands should not change things if nothing needs doing
/home/user/Github/ofn-install/roles/backup/tasks/main.yml:16
Task/Handler: backup remote database

[306] Shells that use pipes should set the pipefail option
/home/user/Github/ofn-install/roles/backup/tasks/main.yml:16
Task/Handler: backup remote database

[503] Tasks that run when changed should likely be handlers
/home/user/Github/ofn-install/roles/db_integrations/tasks/main.yml:17
Task/Handler: Grant permissions

[301] Commands should not change things if nothing needs doing
/home/user/Github/ofn-install/roles/rollback/tasks/main.yml:13
Task/Handler: close active db connections

[204] Lines should be no longer than 160 chars
/home/user/Github/ofn-install/roles/rollback/tasks/main.yml:14
  shell: psql -c "REVOKE CONNECT ON DATABASE {{ db }} FROM public; SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='{{ db }}' AND pid <> pg_backend_pid();"

[403] Package installs should not use latest
/home/user/Github/ofn-install/roles/semaphore_deployment/tasks/main.yml:8
Task/Handler: install ansible

[305] Use shell only when shell functionality is required
/home/user/Github/ofn-install/roles/semaphore_deployment/tasks/main.yml:56
Task/Handler: copy public key

[503] Tasks that run when changed should likely be handlers
playbooks/postgres_tuning.yml:43
Task/Handler: Reload postgres

[301] Commands should not change things if nothing needs doing
playbooks/restore_backup.yml:7
Task/Handler: restore backup

```
