### PR TITLE
Datadog config

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -128,6 +128,17 @@ unicorn_timeout: 30
 
 nginx_official_repo: True
 
+nginx_http_params:
+  - sendfile "on"
+  - tcp_nopush "on"
+  - tcp_nodelay "on"
+  - keepalive_timeout "65"
+  - log_format nginx '$remote_addr - $remote_user [$time_local] ' '"$request" $status $body_bytes_sent $request_time ' '"$http_referer" "$http_user_agent"'
+  - access_log "{{nginx_log_dir}}/access.log" nginx
+  - "error_log {{nginx_log_dir}}/error.log error"
+  - server_tokens off
+  - types_hash_max_size 2048
+
 nginx_sites:
   default:
     - |

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -90,11 +90,11 @@ postgresql_global_config_options:
   - option: logging_collector
     value: on
   - option: log_directory
-    value: 'pg_log'
+    value: '/var/log/pg_log'
   - option: log_filename
     value: 'postgresql-%Y-%m-%d_%H%M%S.log'
   - option: log_file_mode
-    value: 0600
+    value: 0640
   - option: log_truncate_on_rotation
     value: on
   - option: log_rotation_age

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -79,28 +79,8 @@ postgres_listen_addresses:
 postgresql_global_config_options:
   - option: listen_addresses
     value: "{{ postgres_listen_addresses | join(',') }}"
-  - option: shared_preload_libraries
-    value: 'pg_stat_statements'
-  - option: pg_stat_statements.track
-    value: all
-  - option: pg_stat_statements.max
-    value: 10000
-  - option: log_destination
-    value: 'stderr'
-  - option: logging_collector
-    value: on
-  - option: log_directory
-    value: '/var/log/pg_log'
-  - option: log_filename
-    value: 'postgresql-%Y-%m-%d_%H%M%S.log'
-  - option: log_file_mode
-    value: 0640
-  - option: log_truncate_on_rotation
-    value: on
-  - option: log_rotation_age
-    value: 131490 # 3 months
-  - option: log_statement
-    value: 'all'
+  - option: include_dir
+    value: "conf.d"
 
 
 #----------------------------------------------------------------------

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -73,3 +73,10 @@ smtp_password:
 #  - { user: zapier, state: present, password: incredibly_strong_password_goes_here }
 
 
+# For Datadog you will need the following:
+#
+#datadog_db_password: secure_password_goes_here
+#
+#db_integrations:
+#  - { user: datadog, state: present, password: "{{ datadog_db_password }}" }
+

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -23,6 +23,22 @@
           username: "ansible executed by {{ lookup('env','USER') }}"
         when: inventory_hostname not in groups['local']
 
+      - name: Notify datadog
+        uri:
+          url: "https://api.datadoghq.com/api/v1/events?api_key={{ datadog_key }}"
+          method: POST
+          body:
+            title: "Deployed"
+            text: "Successful deployment on host: {{ inventory_hostname }} ({{ ansible_limit }})"
+            host: "{{ inventory_hostname }}"
+            tags:
+              - "deployed"
+          body_format: json
+          status_code: 202
+          headers:
+            Content-Type: "application/json"
+        when: datadog_key is defined and inventory_hostname not in groups['local']
+
       rescue:
         - name: Notify slack of deployment failure
           slack:

--- a/playbooks/postgres_tuning.yml
+++ b/playbooks/postgres_tuning.yml
@@ -9,18 +9,6 @@
         name: geerlingguy.postgresql
         tasks_from: variables
 
-    - name: Create postgres conf.d directory
-      file:
-        dest: "{{ postgresql_config_path }}/conf.d"
-        state: directory
-      become: yes
-
-    - name: Enable conf.d directory
-      lineinfile:
-        path: "{{ postgresql_config_path }}/postgresql.conf"
-        line: "include_dir 'conf.d'"
-      become: yes
-
     - name: Add tuning configuration
       copy:
         content: |
@@ -31,6 +19,7 @@
           work_mem = 6MB
         dest: "{{ postgresql_config_path }}/conf.d/tuning.conf"
       become: yes
+      become_user: postgres
       notify: reload postgres
       when: remove_postgres_tuning is undefined
 

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -77,7 +77,6 @@
 
     - role: datadog
       become: yes
-      when: datadog_key is defined
       tags: datadog
 
   tasks:

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -10,6 +10,9 @@
     - include_role:
         name: check_secrets
 
+  handlers:
+    - include: ../roles/shared_handlers/handlers/main.yml
+
   roles:
     - role: ssh_keys # Add sysadmin ssh keys to server
       become: yes

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -75,15 +75,8 @@
     - role: webserver # Build the unicorn webserver.
       tags: webserver
 
-    - role: Datadog.datadog
+    - role: datadog
       become: yes
-      vars:
-        datadog_api_key: "{{ datadog_key }}"
-        datadog_config:
-          hostname: "{{ inventory_hostname }}"
-          tags:
-            - "env:{{ rails_env }}"
-            - "host-id:{{ ansible_limit }}"
       when: datadog_key is defined
       tags: datadog
 

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -79,6 +79,11 @@
       become: yes
       vars:
         datadog_api_key: "{{ datadog_key }}"
+        datadog_config:
+          hostname: "{{ inventory_hostname }}"
+          tags:
+            - "env:{{ rails_env }}"
+            - "host-id:{{ ansible_limit }}"
       when: datadog_key is defined
       tags: datadog
 

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -88,6 +88,8 @@
       tags: datadog
 
   tasks:
+    - meta: flush_handlers # Ensure handlers run successfully before reporting success
+
     - name: notify slack
       slack:
         token: "T02G54U79/BF25P9F7A/DJdtYaLLUpRJPiu72d8NqgGg"
@@ -95,3 +97,19 @@
         channel: "#devops-notifications"
         username: "ansible executed by {{ lookup('env','USER') }}"
       when: inventory_hostname not in groups['local']
+
+    - name: notify datadog
+      uri:
+        url: "https://api.datadoghq.com/api/v1/events?api_key={{ datadog_key }}"
+        method: POST
+        body:
+          title: "Provisioned"
+          text: "Provisioned host: {{ inventory_hostname }} ({{ ansible_limit }})"
+          host: "{{ inventory_hostname }}"
+          tags:
+            - "provisioned"
+        body_format: json
+        status_code: 202
+        headers:
+          Content-Type: "application/json"
+      when: datadog_key is defined and inventory_hostname not in groups['local']

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -3,9 +3,6 @@
   hosts: ofn_servers
   remote_user: "{{ user }}"
 
-  vars:
-    nginx_daemon_mode: off
-
   pre_tasks:
     - include_role:
         name: check_secrets

--- a/roles/datadog/handlers/main.yml
+++ b/roles/datadog/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: restart datadog-agent
+  service:
+    name: datadog-agent
+    state: restarted
+  become: yes
+  become_user: root

--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-
-- name: set up postgres stats collection
-  import_tasks: pg_stats.yml
-  when: datadog_db_password is defined
-  tags: pg_stats
-
 - name: configure datadog agent
   include_role:
     name: Datadog.datadog
@@ -16,9 +10,14 @@
         - "env:{{ rails_env }}"
         - "host-id:{{ ansible_limit }}"
       logs_enabled: true
-  tags:
-    - pg_stats
-    - configure_datadog
+  when: datadog_key is defined
+
+- name: set up postgres stats collection
+  import_tasks: pg_stats.yml
+  when: datadog_key is defined and datadog_db_password is defined
+
+- name: set up nginx stats collection
+  import_tasks: nginx_stats.yml
   when: datadog_key is defined
 
 - name: disable datadog agent

--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -1,25 +1,9 @@
 ---
-- name: enable postgres logging
-  set_fact:
-    datadog_checks:
-      postgres:
-        init_config:
-        instances:
-          - host: localhost
-            port: 5432
-            username: datadog
-            password: "{{ datadog_db_password }}"
-            dbname: "{{ db }}"
-            tags:
-              - "host:{{ inventory_hostname }}"
-            collect_activity_metrics: true
-        logs:
-          - type: file
-            path: /var/log/pg_log/postgresql-*.log
-            source: postgresql
-            sourcecategory: database
-            service: postgres
+
+- name: set up postgres stats collection
+  import_tasks: pg_stats.yml
   when: datadog_db_password is defined
+  tags: pg_stats
 
 - name: configure datadog agent
   include_role:

--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: enable postgres logging
+  set_fact:
+    datadog_checks:
+      postgres:
+        init_config:
+        instances:
+          - host: localhost
+            port: 5432
+            username: datadog
+            password: "{{ datadog_db_password }}"
+            dbname: "{{ db }}"
+            tags:
+              - "host:{{ inventory_hostname }}"
+            collect_activity_metrics: true
+        logs:
+          - type: file
+            path: /var/log/pg_log/postgresql-*.log
+            source: postgresql
+            sourcecategory: database
+            service: postgres
+  when: datadog_db_password is defined
+
+- name: configure datadog agent
+  include_role:
+    name: Datadog.datadog
+  vars:
+    datadog_api_key: "{{ datadog_key }}"
+    datadog_config:
+      hostname: "{{ inventory_hostname }}"
+      tags:
+        - "env:{{ rails_env }}"
+        - "host-id:{{ ansible_limit }}"
+      logs_enabled: true
+  when: datadog_key is defined

--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -33,3 +33,9 @@
         - "host-id:{{ ansible_limit }}"
       logs_enabled: true
   when: datadog_key is defined
+
+- name: disable datadog agent
+  service:
+    name: datadog-agent
+    state: stopped
+  when: disable_datadog is defined

--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -16,6 +16,9 @@
         - "env:{{ rails_env }}"
         - "host-id:{{ ansible_limit }}"
       logs_enabled: true
+  tags:
+    - pg_stats
+    - configure_datadog
   when: datadog_key is defined
 
 - name: disable datadog agent

--- a/roles/datadog/tasks/nginx_stats.yml
+++ b/roles/datadog/tasks/nginx_stats.yml
@@ -1,0 +1,28 @@
+---
+- name: enable nginx stub_status
+  template:
+    src: status.conf.j2
+    dest: /etc/nginx/conf.d/status.conf
+    mode: 0644
+    owner: root
+    group: 'www-data'
+  become: yes
+  notify:
+    - reload nginx
+    - restart datadog-agent
+
+- name: add datadog agent to adm group
+  user:
+    name: 'dd-agent'
+    groups: adm
+    append: yes
+
+- name: enable datadog nginx integration
+  template:
+    src: dd-nginx.j2
+    dest: /etc/datadog-agent/conf.d/nginx.d/conf.yaml
+    owner: 'dd-agent'
+    group: 'dd-agent'
+    mode: 0644
+  become: true
+  notify: restart datadog-agent

--- a/roles/datadog/tasks/nginx_stats.yml
+++ b/roles/datadog/tasks/nginx_stats.yml
@@ -16,6 +16,7 @@
     name: 'dd-agent'
     groups: adm
     append: yes
+  when: enable_datadog_logging is defined
 
 - name: enable datadog nginx integration
   template:

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -1,0 +1,53 @@
+---
+
+- name: enable postgres logging
+  set_fact:
+    datadog_checks:
+      postgres:
+        init_config:
+        instances:
+          - host: localhost
+            port: 5432
+            username: datadog
+            password: "{{ datadog_db_password }}"
+            dbname: "{{ db }}"
+            tags:
+              - "host:{{ inventory_hostname }}"
+            collect_activity_metrics: true
+        logs:
+          - type: file
+            path: /var/log/pg_log/postgresql-*.log
+            source: postgresql
+            sourcecategory: database
+            service: postgres
+  when: datadog_db_password is defined
+
+- name: check datadog db_integration exists
+  command: psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='datadog'"
+  become: yes
+  become_user: postgres
+  register: integration_exists
+  changed_when: False
+
+- fail:
+    msg: "The database role `datadog` has not been created. Add it via the `db_integrations` playbook."
+  when: integration_exists.stdout != '1'
+
+- name: check datadog views
+  command: psql -c "SELECT * FROM pg_catalog.pg_views WHERE viewname = 'pg_stat_activity_dd';"
+  become: yes
+  become_user: postgres
+  register: stat_views_exist
+  changed_when: False
+
+- name: add pg_stat function and view
+  command: |
+    psql -c "CREATE FUNCTION pg_stat_activity()
+    RETURNS SETOF pg_catalog.pg_stat_activity AS
+    $$ SELECT * from pg_catalog.pg_stat_activity; $$
+    LANGUAGE sql VOLATILE SECURITY DEFINER;
+    CREATE VIEW pg_stat_activity_dd AS SELECT * FROM pg_stat_activity();
+    grant SELECT ON pg_stat_activity_dd to datadog;"
+  become: yes
+  become_user: postgres
+  when: stat_views_exist.stdout.find('0 rows') != -1

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -19,6 +19,10 @@
             source: postgresql
             sourcecategory: database
             service: postgres
+            log_processing_rules:
+              - type: multi_line
+                pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+                name: new_log_start_with_date
   when: datadog_db_password is defined
 
 - name: add datadog agent to postgres group

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: enable postgres logging
   set_fact:
     datadog_checks:
@@ -20,6 +19,13 @@
             source: postgresql
             sourcecategory: database
             service: postgres
+  when: datadog_db_password is defined
+
+- name: add datadog agent to postgres group
+  user:
+    name: 'dd-agent'
+    groups: postgres
+    append: yes
   when: datadog_db_password is defined
 
 - name: check datadog db_integration exists

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -1,4 +1,36 @@
 ---
+- name: create extensions
+  become: yes
+  become_user: postgres
+  postgresql_ext:
+    name: pg_stat_statements
+    db: "{{ db }}"
+
+- name: gather postgres installation info
+  include_role:
+    name: geerlingguy.postgresql
+    tasks_from: variables
+  when: postgresql_config_path is undefined
+
+- name: add logging configuration
+  copy:
+    content: |
+      shared_preload_libraries = 'pg_stat_statements'
+      pg_stat_statements.track = 'all'
+      pg_stat_statements.max = '1000'
+      log_destination = 'stderr'
+      logging_collector = on
+      log_directory = '/var/log/pg_log'
+      log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'
+      log_file_mode = 0640
+      log_truncate_on_rotation = on
+      log_rotation_age = 131490 # 3 months
+      log_statement = 'all'
+    dest: "{{ postgresql_config_path }}/conf.d/logging.conf"
+  become: yes
+  become_user: postgres
+  notify: restart postgres
+
 - name: enable postgres logging
   set_fact:
     datadog_checks:

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -12,6 +12,16 @@
     tasks_from: variables
   when: enable_datadog_logging is defined and postgresql_config_path is undefined
 
+- name: add postgres stats configuration
+  template:
+    src: stats.conf.j2
+    dest: "{{ postgresql_config_path }}/conf.d/stats.conf"
+    owner: postgres
+    group: postgres
+    mode: 0640
+  become: yes
+  notify: restart postgres
+
 - name: add postgres logging configuration
   template:
     src: logging.conf.j2

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -23,6 +23,9 @@
               - type: multi_line
                 pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
                 name: new_log_start_with_date
+              - type: exclude_at_match
+                name: exclude_datadog_stat_collection
+                pattern: datadog@openfoodnetwork\ LOG
   when: datadog_db_password is defined
 
 - name: add datadog agent to postgres group

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -12,53 +12,26 @@
     tasks_from: variables
   when: postgresql_config_path is undefined
 
-- name: add logging configuration
-  copy:
-    content: |
-      shared_preload_libraries = 'pg_stat_statements'
-      pg_stat_statements.track = 'all'
-      pg_stat_statements.max = '1000'
-      log_destination = 'stderr'
-      logging_collector = on
-      log_directory = '/var/log/pg_log'
-      log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'
-      log_file_mode = 0640
-      log_truncate_on_rotation = on
-      log_rotation_age = 2880 # 2 days
-      log_statement = 'all'
+- name: add postgres logging configuration
+  template:
+    src: logging.conf.j2
     dest: "{{ postgresql_config_path }}/conf.d/logging.conf"
+    owner: postgres
+    group: postgres
+    mode: 0640
   become: yes
-  become_user: postgres
   notify: restart postgres
 
-- name: enable postgres logging
-  set_fact:
-    datadog_checks:
-      postgres:
-        init_config:
-        instances:
-          - host: localhost
-            port: 5432
-            username: datadog
-            password: "{{ datadog_db_password }}"
-            dbname: "{{ db }}"
-            tags:
-              - "host:{{ inventory_hostname }}"
-            collect_activity_metrics: true
-        logs:
-          - type: file
-            path: /var/log/pg_log/postgresql-*.log
-            source: postgresql
-            sourcecategory: database
-            service: postgres
-            log_processing_rules:
-              - type: multi_line
-                pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
-                name: new_log_start_with_date
-              - type: exclude_at_match
-                name: exclude_datadog_stat_collection
-                pattern: datadog@openfoodnetwork\ LOG
+- name: enable datadog postgres integration
+  template:
+    src: dd-postgres.j2
+    dest: /etc/datadog-agent/conf.d/postgres.d/conf.yaml
+    owner: 'dd-agent'
+    group: 'dd-agent'
+    mode: 0644
+  become: true
   when: datadog_db_password is defined
+  notify: restart datadog-agent
 
 - name: add datadog agent to postgres group
   user:
@@ -97,3 +70,4 @@
   become: yes
   become_user: postgres
   when: stat_views_exist.stdout.find('0 rows') != -1
+  notify: restart postgres

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -24,7 +24,7 @@
       log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'
       log_file_mode = 0640
       log_truncate_on_rotation = on
-      log_rotation_age = 131490 # 3 months
+      log_rotation_age = 2880 # 2 days
       log_statement = 'all'
     dest: "{{ postgresql_config_path }}/conf.d/logging.conf"
   become: yes

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -29,7 +29,8 @@
   register: integration_exists
   changed_when: False
 
-- fail:
+- name: report db_integration status
+  fail:
     msg: "The database role `datadog` has not been created. Add it via the `db_integrations` playbook."
   when: integration_exists.stdout != '1'
 

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -10,7 +10,7 @@
   include_role:
     name: geerlingguy.postgresql
     tasks_from: variables
-  when: postgresql_config_path is undefined
+  when: enable_datadog_logging is defined and postgresql_config_path is undefined
 
 - name: add postgres logging configuration
   template:
@@ -21,6 +21,7 @@
     mode: 0640
   become: yes
   notify: restart postgres
+  when: enable_datadog_logging is defined
 
 - name: enable datadog postgres integration
   template:
@@ -38,7 +39,7 @@
     name: 'dd-agent'
     groups: postgres
     append: yes
-  when: datadog_db_password is defined
+  when: datadog_db_password is defined and enable_datadog_logging is defined
 
 - name: check datadog db_integration exists
   command: psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='datadog'"

--- a/roles/datadog/templates/dd-nginx.j2
+++ b/roles/datadog/templates/dd-nginx.j2
@@ -1,0 +1,21 @@
+# See: http://docs.datadoghq.com/integrations/nginx/
+
+init_config:
+
+instances:
+  - nginx_status_url: http://localhost:81/nginx_status/
+    tags:
+      - "host:{{ inventory_hostname }}"
+
+logs:
+  - type: file
+    path: /var/log/nginx/access.log
+    service: nginx
+    source: nginx
+    sourcecategory: http_web_access
+
+  - type: file
+    path: /var/log/nginx/error.log
+    service: nginx
+    source: nginx
+    sourcecategory: http_web_access

--- a/roles/datadog/templates/dd-nginx.j2
+++ b/roles/datadog/templates/dd-nginx.j2
@@ -7,6 +7,7 @@ instances:
     tags:
       - "host:{{ inventory_hostname }}"
 
+{% if enable_datadog_logging is defined %}
 logs:
   - type: file
     path: /var/log/nginx/access.log
@@ -19,3 +20,4 @@ logs:
     service: nginx
     source: nginx
     sourcecategory: http_web_access
+{% endif %}

--- a/roles/datadog/templates/dd-postgres.j2
+++ b/roles/datadog/templates/dd-postgres.j2
@@ -1,0 +1,26 @@
+# See: https://docs.datadoghq.com/integrations/postgres/
+
+init_config:
+
+instances:
+  - host: localhost
+    port: 5432
+    username: datadog
+    password: "{{ datadog_db_password }}"
+    dbname: "{{ db }}"
+    tags:
+      - "host:{{ inventory_hostname }}"
+    collect_activity_metrics: true
+logs:
+  - type: file
+    path: /var/log/pg_log/postgresql-*.log
+    source: postgresql
+    sourcecategory: database
+    service: postgres
+    log_processing_rules:
+      - type: multi_line
+        pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
+        name: new_log_start_with_date
+      - type: exclude_at_match
+        name: exclude_datadog_stat_collection
+        pattern: datadog@openfoodnetwork\ LOG

--- a/roles/datadog/templates/dd-postgres.j2
+++ b/roles/datadog/templates/dd-postgres.j2
@@ -11,6 +11,8 @@ instances:
     tags:
       - "host:{{ inventory_hostname }}"
     collect_activity_metrics: true
+
+{% if enable_datadog_logging is defined %}
 logs:
   - type: file
     path: /var/log/pg_log/postgresql-*.log
@@ -24,3 +26,4 @@ logs:
       - type: exclude_at_match
         name: exclude_datadog_stat_collection
         pattern: datadog@openfoodnetwork\ LOG
+{% endif %}

--- a/roles/datadog/templates/logging.conf.j2
+++ b/roles/datadog/templates/logging.conf.j2
@@ -1,6 +1,3 @@
-shared_preload_libraries = 'pg_stat_statements'
-pg_stat_statements.track = 'all'
-pg_stat_statements.max = '1000'
 log_destination = 'stderr'
 logging_collector = on
 log_directory = '/var/log/pg_log'

--- a/roles/datadog/templates/logging.conf.j2
+++ b/roles/datadog/templates/logging.conf.j2
@@ -1,0 +1,11 @@
+shared_preload_libraries = 'pg_stat_statements'
+pg_stat_statements.track = 'all'
+pg_stat_statements.max = '1000'
+log_destination = 'stderr'
+logging_collector = on
+log_directory = '/var/log/pg_log'
+log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'
+log_file_mode = 0640
+log_truncate_on_rotation = on
+log_rotation_age = 2880 # 2 days
+log_statement = 'all'

--- a/roles/datadog/templates/stats.conf.j2
+++ b/roles/datadog/templates/stats.conf.j2
@@ -1,0 +1,3 @@
+shared_preload_libraries = 'pg_stat_statements'
+pg_stat_statements.track = 'all'
+pg_stat_statements.max = '1000'

--- a/roles/datadog/templates/status.conf.j2
+++ b/roles/datadog/templates/status.conf.j2
@@ -1,0 +1,12 @@
+server {
+  listen 81;
+  server_name localhost;
+
+  access_log off;
+  allow 127.0.0.1;
+  deny all;
+
+  location /nginx_status {
+    stub_status;
+  }
+}

--- a/roles/dbserver/tasks/main.yml
+++ b/roles/dbserver/tasks/main.yml
@@ -1,4 +1,12 @@
 --- # dbserver
+- name: create custom log directory
+  file:
+    state: directory
+    dest: /var/log/pg_log
+    mode: 0750
+    owner: postgres
+    group: postgres
+  become: yes
 
 - import_tasks: postgresql.yml # Install postgresql with geerlingguy.postgresql role
 

--- a/roles/dbserver/tasks/main.yml
+++ b/roles/dbserver/tasks/main.yml
@@ -1,5 +1,6 @@
 --- # dbserver
-- name: create custom log directory
+
+- name: add custom log directory
   file:
     state: directory
     dest: /var/log/pg_log
@@ -9,6 +10,15 @@
   become: yes
 
 - import_tasks: postgresql.yml # Install postgresql with geerlingguy.postgresql role
+
+- name: add postgres conf.d directory
+  file:
+    dest: "{{ postgresql_config_path }}/conf.d"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: 0740
+  become: yes
 
 - name: add .pgpass file for {{ unicorn_user }}
   template:
@@ -22,9 +32,3 @@
 - import_tasks: fix_template_encoding.yml
   tags: template_encoding
 
-- name: create extensions
-  become: yes
-  become_user: postgres
-  postgresql_ext:
-    name: pg_stat_statements
-    db: "{{ db }}"

--- a/roles/shared_handlers/handlers/main.yml
+++ b/roles/shared_handlers/handlers/main.yml
@@ -20,3 +20,10 @@
     state: restarted
   become: yes
   become_user: root
+
+- name: restart postgres
+  service:
+    name: postgresql
+    state: restarted
+  become: yes
+  become_user: root


### PR DESCRIPTION
Closes #305 

This PR: 
- improves our current Datadog settings
- notifies Datadog on a successful deploy or provision
- enables collection of postgresql stats and logs through the Datadog agent
- also enables nginx stats and logging to Datadog

![Screenshot-2019-04-25-13-21:57](https://user-images.githubusercontent.com/9029026/56735364-2c0a4200-675d-11e9-9d5b-a211f9a5e60f.png)

:warning: Provisioning the new postgres stats and logging features to a server requires adding or updating these variables in `secrets.yml`:

```ruby
datadog_db_password: <secure_password_goes_here> # use $ openssl rand -hex 128

db_integrations:
  - { user: datadog, state: present, password: "{{ datadog_db_password }}" }
```
And if you havn't done it already, you'll also need to run `playbooks/db_integrations.yml` first to create the database user and grant them permissions.
