### PR TITLE
Allow passing a specific AWS region to S3 settings

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -20,6 +20,7 @@ google_maps_api_key:
 # Set these if using Amazon S3
 #s3_access_key:
 #s3_secret:
+#s3_region:
 #s3_images_bucket:
 #s3_backups_bucket:
 

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -24,6 +24,9 @@ S3_ACCESS_KEY: {{ s3_access_key }}
 {% if s3_secret is defined %}
 S3_SECRET: {{ s3_secret }}
 {% endif %}
+{% if s3_region is defined %}
+S3_REGION: {{ s3_region }}
+{% endif %}
 {% if s3_backups_bucket is defined %}
 S3_BACKUPS_BUCKET: {{ s3_backups_bucket }}
 {% endif %}


### PR DESCRIPTION
No need to rely on the default region Db2fog might specify. Needed for https://github.com/openfoodfoundation/openfoodnetwork/pull/3763.