### PR TITLE
Set unicorn_timeout for OFN DE to 120

### DIFF
--- a/inventory/host_vars/openfoodnetwork.de/config.yml
+++ b/inventory/host_vars/openfoodnetwork.de/config.yml
@@ -4,3 +4,5 @@ rails_env: production
 admin_email: admin@openfoodfoundation.org
 
 mail_domain: openfoodnetwork.de
+
+unicorn_timeout: 120


### PR DESCRIPTION
Set `unicorn_timeout` for OFN DE to 120.

## Description

This sets the Unicorn timeout for OFN DE to 120. 

It is not confirmed if a Unicorn timeout causes the HTTP 500 when using a large dataset for product import. But, considering that large data imports will be done, this change is appropriate anyway.

This is similar to #238 and #290.

Actually, I'm wondering if we should set the default `unicorn_timeout` to 120 for all instances. But that's outside the scope of this PR.