### PR TITLE
Create log directory after postgres installation

### DIFF
--- a/roles/dbserver/tasks/main.yml
+++ b/roles/dbserver/tasks/main.yml
@@ -1,5 +1,7 @@
 --- # dbserver
 
+- import_tasks: postgresql.yml # Install postgresql with geerlingguy.postgresql role
+
 - name: add custom log directory
   file:
     state: directory
@@ -8,8 +10,6 @@
     owner: postgres
     group: postgres
   become: yes
-
-- import_tasks: postgresql.yml # Install postgresql with geerlingguy.postgresql role
 
 - name: add postgres conf.d directory
   file:


### PR DESCRIPTION
It seems like on some hosts the postgres user might not exist on a fresh install, which can cause an error here. I've switched the task order just to be safe.