### PR TITLE
Adjust ENV vars for db:seed 

### DIFF
--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -18,6 +18,9 @@ CHECKOUT_ZONE: {{ checkout_zone }}
 
 GOOGLE_MAPS_API_KEY: {{ google_maps_api_key }}
 
+ADMIN_EMAIL: {{ admin_email }}
+ADMIN_PASSWORD: {{ admin_password }}
+
 {% if s3_access_key is defined %}
 S3_ACCESS_KEY: {{ s3_access_key }}
 {% endif %}

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -96,7 +96,7 @@
     - restart unicorn
 
 - name: seed database
-  command: bash -lc "bundle exec rake db:seed RAILS_ENV={{ rails_env }} ADMIN_EMAIL={{ admin_email }} ADMIN_PASSWORD={{ admin_password }}"
+  command: bash -lc "bundle exec rake db:seed RAILS_ENV={{ rails_env }}"
   args:
     chdir: "{{ current_path }}"
   tags:


### PR DESCRIPTION
Needed to resolve issues with Semaphore deployments, and some manual deployments (depending on local dev setup).

Moves variables defined in `secrets.yml` out of `deploy.yml`. 

The db:seed task needs those two ENV vars to be available, but we shouldn't reference them directly in `deploy.yml`, as we have decoupled it from `secrets.yml`.