### PR TITLE
Ensure certificates are present for www and naked url

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -168,7 +168,7 @@ nginx_sites:
     - |
       listen 80;
       listen [::]:80;
-      server_name {{ domain }};
+      server_name {{ certbot_domains | default([domain]) | join(' ') }};
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;
@@ -186,7 +186,7 @@ nginx_sites:
     - |
       listen 443 ssl http2;
       listen [::]:443 ssl http2;
-      server_name {{ domain }};
+      server_name {{ certbot_domains | default([domain]) | join(' ') }};
       root {{ app_root }}/public;
 
       ssl_certificate      /etc/letsencrypt/live/{{ certbot_cert_name | default(domain) }}/fullchain.pem;

--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -8,6 +8,10 @@ unicorn_timeout: 120
 
 swapfile_size: 1G
 
+certbot_domains:
+  - www.openfoodnetwork.org.uk
+  - openfoodnetwork.org.uk
+
 postgres_listen_addresses:
   - '*'
 

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -64,7 +64,7 @@
       vars:
         domain_name: "{{ certbot_domains | default([domain]) | join(',') }}"
         letsencrypt_email: "{{ developer_email }}"
-        certbot_nginx_cert_name: "{{ certbot_cert_name | default(None) }}"
+        certbot_nginx_cert_name: "{{ certbot_cert_name | default(domain) }}"
       when: inventory_hostname not in groups['local']
       tags: certbot
 


### PR DESCRIPTION
We had some reports of browsers intermittently failing to load the homepage when using the naked url `openfoodnetwork.org.uk`. At first it seemed to just be in Internet Explorer :nauseated_face: but it turned out to be intermittently affecting Firefox and Chrome as well. It turned out to be quite a critical issue, as multiple users were finding the site didn't load at all!

This seems to have resolved the problem on UK prod. It looks like France needs this as well, and probably others. We should double-check Katuma prod when provisioning this, as it has a setup with custom domains.
