### PR TITLE
Adapt nginx timeouts to unicorn configuration

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -215,7 +215,9 @@ nginx_sites:
 
       error_page 500 502 503 504 /500.html;
       client_max_body_size 4G;
-      keepalive_timeout 60;
+      keepalive_timeout {{ unicorn_timeout }};
+      proxy_read_timeout {{ unicorn_timeout }};
+      proxy_send_timeout {{ unicorn_timeout }};
 
       include /etc/nginx/sites-available/ofn/*;
 


### PR DESCRIPTION
We had several cases in which we wanted to increase the timeout to over a minute. While unicorn was running longer than a minute (e.g. `unicorn_timeout 120`), nginx was shutting down the connection after one minute. Now we have the same timeout for nginx and unicorn.

This is needed for Germany and Australia to keep the current configuration. France and UK also have a unicorn timeout of 120 configured and this change may fix some performance problems. When there are many requests, there can be a queue build-up. When the unicorn timeout is longer than the nginx timeout, unicorn will still be busy when nginx tries to pass on the next request.