### PR TITLE
Bump coopdevs.certbot_nginx role

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -9,7 +9,7 @@
   version: v2.8.1
 
 - src: coopdevs.certbot_nginx
-  version: 0.0.3
+  version: 0.0.4
 
 - src: oefenweb.swapfile
   version: v2.0.14


### PR DESCRIPTION
Closes #392 

This fixes some issues with certbot on new servers.