### PR TITLE
Increase Katuma's available swap

### DIFF
--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -12,4 +12,4 @@ certbot_domains:
 
 certbot_cert_name: app.katuma.org
 
-swapfile_size: 1G
+swapfile_size: 2G


### PR DESCRIPTION
Apparently, server ate up almost all the swap while precompiling assets
for the deploy of
https://github.com/openfoodfoundation/openfoodnetwork/releases/tag/v2.0.2,
as shown in
https://openfoodnetwork.slack.com/archives/CEF14NU3V/p1559721636000600.

I feel ashamed but we have no resources to manage a server upgrade while
being busy with the v2 roll-out, the hiring of a new employee in Katuma
and other Coopdevs duties with the right focus. This will again buy some
more time.