### PR TITLE
Asset migration playbook and role

### DIFF
--- a/playbooks/pull_assets.yml
+++ b/playbooks/pull_assets.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Pull assets
+  hosts: ofn_servers
+  remote_user: "{{ user }}"
+
+  tasks:
+    - include_role:
+        name: migrate_assets
+      vars:
+        sync_mode: pull

--- a/playbooks/push_assets.yml
+++ b/playbooks/push_assets.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Push assets
+  hosts: ofn_servers
+  remote_user: "{{ user }}"
+
+  tasks:
+    - include_role:
+        name: migrate_assets
+      vars:
+        sync_mode: push

--- a/roles/migrate_assets/defaults/main.yml
+++ b/roles/migrate_assets/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+
+source_path: "{{ shared_path }}"
+dest_path: "{{ shared_path }}"
+local_asset_path: "../backups"
+
+migrate_dirs:
+  - assets
+  - spree
+  - system

--- a/roles/migrate_assets/tasks/main.yml
+++ b/roles/migrate_assets/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: migrate asset directories
+  include_tasks: "{{ sync_mode }}_assets.yml"
+  loop: "{{ migrate_dirs }}"
+  loop_control:
+    loop_var: migrate_dir
+
+

--- a/roles/migrate_assets/tasks/pull_assets.yml
+++ b/roles/migrate_assets/tasks/pull_assets.yml
@@ -1,0 +1,9 @@
+---
+
+- name: download assets
+  synchronize:
+    src: "{{ dest_path }}/{{ migrate_dir }}"
+    dest: "{{ local_asset_path }}/"
+    mode: pull
+  become: yes
+  become_user: "{{ unicorn_user }}"

--- a/roles/migrate_assets/tasks/push_assets.yml
+++ b/roles/migrate_assets/tasks/push_assets.yml
@@ -1,0 +1,9 @@
+---
+
+- name: upload assets
+  synchronize:
+    src: "{{ local_asset_path }}/{{ migrate_dir }}"
+    dest: "{{ dest_path }}/"
+    mode: push
+  become: yes
+  become_user: "{{ unicorn_user }}"


### PR DESCRIPTION
Part of the Canada migration #339.

Playbooks for migrating all the static assets from one server to another.

~~Copies contents of OFN asset folders from one server to another recursively, by executing `scp` on the control machine using the `-3` flag: the user's machine will connect to both the source and destination via SSH and act as a mid-way point for the transfer.~~

My initial version of this was really slow. I've switched to using rsync via the `synchronise` module, and now it's 100 times faster. :tada: