### PR TITLE
Temporary configs for the Canada migration

### DIFF
--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -3,4 +3,40 @@
 domain: openfoodnetwork.ca
 rails_env: production
 
-admin_email:
+admin_email: admin@openfoodnetwork.ca
+mail_domain: openfoodnetwork.ca
+
+swapfile_size: 2G
+
+certbot_domains:
+  - openfoodnetwork.ca
+  - www.openfoodnetwork.ca
+  - upgrade.openfoodnetwork.ca
+
+
+# Letsencrpyt validation proxy-hack so we can register certificates on the new server
+# Works like a charm! :D
+# Delete and provision again when finished...
+ofn_80:
+  - |
+    listen 80;
+    listen [::]:80;
+    server_name {{ certbot_domains | default([domain]) | join(' ') }};
+
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Xss-Protection "1; mode=block" always;
+
+    location '/.well-known/acme-challenge' {
+      # Now we can validate a multi-domain certificate for openfoodnetwork.ca from the *other* server
+      # without affecting anything on the current server.
+      proxy_pass http://upgrade.openfoodnetwork.ca/.well-known/acme-challenge;
+      proxy_set_header    Host            $host;
+      proxy_set_header    X-Real-IP       $remote_addr;
+      proxy_set_header    X-Forwarded-for $remote_addr;
+      port_in_redirect off;
+      proxy_connect_timeout 300;
+    }
+
+    location / {
+      return 301 https://$host$request_uri;
+    }

--- a/inventory/host_vars/upgrade.openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/upgrade.openfoodnetwork.ca/config.yml
@@ -1,0 +1,16 @@
+---
+
+domain: upgrade.openfoodnetwork.ca
+rails_env: production
+
+admin_email: admin@openfoodnetwork.ca
+mail_domain: openfoodnetwork.ca
+
+swapfile_size: 2G
+
+certbot_domains:                        # The order here is important
+  - openfoodnetwork.ca
+  - www.openfoodnetwork.ca
+  - upgrade.openfoodnetwork.ca
+
+certbot_cert_name: openfoodnetwork.ca   # This bit is very important

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -32,10 +32,14 @@ au-staging
 # Canada
 
 [ca-prod]
-openfoodnetwork.ca
+openfoodnetwork.ca ansible_host=159.203.30.206
+
+[ca-prod2]
+upgrade.openfoodnetwork.ca ansible_host=68.183.204.127
 
 [ca:children]
 ca-prod
+ca-prod2
 
 #------------------------------------------------------------------------------
 # Ireland


### PR DESCRIPTION
We shouldn't merge this, but I thought it was worth posting up so it's visible.

We can use this as a reference for future migrations.

It turns out migrating a server where the domain name is the same is pretty complicated! I've made a few playbooks today to automate a lot of the migration steps, and this is the final bit of hacking I came up with so we can create the new TLS certificates before doing the switch.

- Use the awesome new support for multi-domain certificates and multi-domain redirects that got merged the other day :wink:
- Use some proxing magic for the Letsencrypt validation check so Certbot can validate both domains from the new host while the old one is still runing
- Create a multi-domain certificate on the new host so the cert is valid for both
