### PR TITLE
Add new switch for connect-and-learn feature

### DIFF
--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -26,5 +26,5 @@ mail_domain: example.com
 #custom_hba_entries:
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 #
-# Feature toggles
-#feature_connect_and_learn: "true"
+#custom_application_env_vars: |
+#  OFN_FEATURE_CONNECT_AND_LEARN: "true"

--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -25,3 +25,6 @@ mail_domain: example.com
 #
 #custom_hba_entries:
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+#
+# Feature toggles
+#feature_connect_and_learn: "true"

--- a/inventory/host_vars/prod2.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/prod2.openfoodnetwork.org.au/config.yml
@@ -28,3 +28,6 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+
+custom_application_env_vars: |
+  OFN_FEATURE_CONNECT_AND_LEARN: "true"

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -46,4 +46,4 @@ STRIPE_ENDPOINT_SECRET: {{ stripe_endpoint_secret }}
 BUGSNAG_API_KEY: {{ bugsnag_key }}
 {% endif %}
 
-OFN_FEATURE_CONNECT_AND_LEARN: "{{ feature_connect_and_learn | default('false') }}"
+{{ custom_application_env_vars | default('') }}

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -45,3 +45,5 @@ STRIPE_ENDPOINT_SECRET: {{ stripe_endpoint_secret }}
 {% if bugsnag_key is defined %}
 BUGSNAG_API_KEY: {{ bugsnag_key }}
 {% endif %}
+
+OFN_FEATURE_CONNECT_AND_LEARN: "{{ feature_connect_and_learn | default('false') }}"


### PR DESCRIPTION
In https://github.com/openfoodfoundation/openfoodnetwork/pull/3970 I'm changing the way feature toggles are switched on or off. It now uses environment variables instead of a hardcoded hash that was set in an initializer.

This is the second and last part of #444.