### PR TITLE
Call apt with list of packages

### DIFF
--- a/roles/language/tasks/main.yml
+++ b/roles/language/tasks/main.yml
@@ -2,8 +2,7 @@
 - name: install language package(s)
   become: yes
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ language_packages }}"
     state: present
-  with_items: "{{ language_packages }}"
   notify:
     - update locales


### PR DESCRIPTION
I saw the following warning:

    Invoking "apt" only once while using a loop via squash_actions is
    deprecated.

Newer versions of the apt module support lists directly and the use of
`with_items` is deprecated.

There are more of these warnings coming from community modules. They should go away when we update those modules.