### PR TITLE
Add Brotli compression support

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -138,6 +138,10 @@ core_devs:
 
 nginx_official_repo: True
 
+nginx_extra_root_params:
+  - load_module modules/ngx_http_brotli_filter_module.so
+  - load_module modules/ngx_http_brotli_static_module.so
+
 nginx_http_params:
   - sendfile "on"
   - tcp_nopush "on"
@@ -198,6 +202,9 @@ nginx_sites:
       gzip on;
       gzip_disable "msie6";
 
+      brotli on;
+      brotli_types text/html text/css text/javascript text/plain application/javascript application/x-javascript application/json;
+
       try_files $uri/index.html $uri @unicorn;
       location @unicorn {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -209,6 +216,7 @@ nginx_sites:
 
       location ~ ^/(assets)/ {
         gzip_static on;
+        brotli_static on;
         expires max;
         add_header Cache-Control public;
       }

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -68,6 +68,9 @@
       when: inventory_hostname not in groups['local']
       tags: certbot
 
+    - role: brotli_nginx
+      tags: brotli
+
     - role: jdauphant.nginx
       become: yes
       tags: nginx

--- a/roles/brotli_nginx/tasks/main.yml
+++ b/roles/brotli_nginx/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+
+- name: add brotli ppa
+  apt_repository:
+    repo: ppa:hda-me/nginx-stable
+  become: yes
+
+- name: install brotli
+  apt:
+    name: [brotli, nginx-module-brotli]
+    state: present
+  become: yes


### PR DESCRIPTION
Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/3858 and https://github.com/openfoodfoundation/openfoodnetwork/issues/#3860

Adds support for [Brotli](https://github.com/google/ngx_brotli) compression.

Tested on UK Staging.