### PR TITLE
Missing semicolon in nginx config

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -219,7 +219,7 @@ nginx_sites:
         }
 
         gzip_proxied no-cache no-store private expired auth;
-        proxy_http_version 1.1
+        proxy_http_version 1.1;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Maybe this got changed whilst resolving a merge conflict the other day? 

There's a missing semicolon in the nginx configs, and it's breaking the `provision.yml` playbook.

![](https://media.giphy.com/media/12YSivm7ltYg2Q/giphy.gif)

Tested on UK staging :heavy_check_mark: 