### PR TITLE
Fix rails_safe_tasks issue with deploying new production servers

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -76,7 +76,7 @@
   tags: rake
 
 - name: load schema if it isn't loaded
-  command: bash -lc "bundle exec rake db:schema:load RAILS_ENV={{ rails_env }}"
+  command: bash -lc "bundle exec rake db:schema:load RAILS_ENV={{ rails_env }} I_AM_SURE=1"
   args:
     chdir: "{{ current_path }}"
   when: table_exists.stdout.find('0 rows') != -1


### PR DESCRIPTION
The addition of the `rails_safe_fix` gem introduced an error in the deploy playbook. It only affects the first deployment on a fresh server with `RAILS_ENV=production`.

One of the tasks in the deploy playbook is blocked by the gem. This fixes the error by allowing the task to proceed.