### PR TITLE
Symlink issue

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -2,10 +2,13 @@
 
 # Build codebase
 
-- name: remove the old build path
+- name: remove the old build paths
   file:
-    dest: "{{ build_path }}"
+    dest: "{{ item }}"
     state: absent
+  with_items:
+    - "{{ build_path }}"
+    - "{{ current_path }}"
   tags: clone
 
 - name: build codebase from git branch
@@ -62,8 +65,10 @@
 
 # Move new build into place
 
-- name: copy build to current
-  command: cp -TLr {{ build_path }} {{ current_path }}
+- name: move build to current
+  command: mv {{ build_path }} {{ current_path }}
+  args:
+    removes: "{{ build_path }}"
   changed_when: True
 
 # Update the database

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -1,7 +1,13 @@
 --- # Deploy
 
+- name: Check if app is deployed
+  stat:
+    path: "{{ current_path }}/"
+  register: current_path_check
+
 - name: Handle rollbacks
   import_tasks: rollbacks.yml
+  when: current_path_check.stat.exists
   tags: rollbacks
 
 - name: Deploy

--- a/roles/deploy/tasks/rollbacks.yml
+++ b/roles/deploy/tasks/rollbacks.yml
@@ -39,10 +39,8 @@
   args:
     creates: "{{ releases_path }}/{{ timestamp }}.sql.gz"
 
-- name: create a repo rollback version
-  command: mv {{ current_path }} {{ rollback_path }}
-  args:
-    removes: "{{ current_path }}"
+- name: create a repo rollback version # noqa 301
+  command: cp -TLr {{ current_path }} {{ rollback_path }}
   register: new_rollback
 
 - name: create a repo backup version

--- a/tests/deploy/setup.yml
+++ b/tests/deploy/setup.yml
@@ -1,0 +1,19 @@
+---
+- name: setup
+  hosts: ofn_servers
+  remote_user: "{{ user }}"
+
+  tasks:
+    - name: setup | deploy | add dummy product image directory
+      become: yes
+      become_user: "{{ unicorn_user }}"
+      file:
+        path: "{{ shared_path }}/spree/products/123/"
+        state: directory
+
+    - name: setup | deploy | add dummy product image
+      become: yes
+      become_user: "{{ unicorn_user }}"
+      file:
+        path: "{{ shared_path }}/spree/products/123/test.png"
+        state: touch

--- a/tests/deploy/test.yml
+++ b/tests/deploy/test.yml
@@ -4,8 +4,21 @@
   remote_user: "{{ user }}"
 
   tasks:
-    - name: test | deploy | expect rollback to exist
+    - name: test | deploy | expect rollback to exist, and contain app files
       stat:
         path: "{{ rollback_path }}/app/"
       register: deploy_test
       failed_when: not deploy_test.stat.exists
+
+    - name: test | deploy | expect symlinked directories in /current to be intact
+      stat:
+        path: "{{ current_path }}/public/spree"
+      register: symlink_test
+      failed_when: not symlink_test.stat.exists or not symlink_test.stat.islnk
+
+    - name: test | deploy | expect images symlinked from /shared to be available in /current
+      stat:
+        path: "{{ current_path }}/public/spree/products/123/test.png"
+      register: image_test
+      failed_when: not image_test.stat.exists
+

--- a/tests/suite.yml
+++ b/tests/suite.yml
@@ -8,6 +8,7 @@
 - import_playbook: ../tests/site/test.yml
 
 # Deploying to a live instance
+- import_playbook: ../tests/deploy/setup.yml
 - import_playbook: ../playbooks/deploy.yml
 - import_playbook: ../tests/deploy/test.yml
 


### PR DESCRIPTION
We previously had a bug related to symlinks that meant files were not being backup up correctly in the /rollbacks directory. The change applied to fix it broke the way images are symlinked into the /current directory, but only affected instances that don't use S3, and probably only became apparent after 2 deploys.

I've made some adjustments and added some additional tests to ensure it doesn't happen again and both issues are resolved.