### PR TITLE
Downscale Germany

### DIFF
--- a/inventory/host_vars/openfoodnetwork.de/config.yml
+++ b/inventory/host_vars/openfoodnetwork.de/config.yml
@@ -20,9 +20,5 @@ swapfile_size: 2G
 #custom_hba_entries:
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
-# The server currently has 8 CPUs and 32 GB of memory.
-# Since they are experimenting with thousands of products and have to
-# report to the government next week (May 2019) we better keep as
-# many resources as possible.
-unicorn_workers: 6
+unicorn_workers: 2
 unicorn_timeout: 360


### PR DESCRIPTION
The German instance is not really used until we get the performance improvements deployed there. Two workers should be good for now. The server has been downscaled to 4 GB.