### PR TITLE
Enable Nginx logs in Datadog

### DIFF
--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -17,3 +17,5 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+
+enable_datadog_logging: true


### PR DESCRIPTION
This will hopefully let us correlate and find the root cause of https://github.com/openfoodfoundation/ofn-install/issues/477.

This adds extra load to the servers and increases costs. That's why we will enable it just temporally.