### PR TITLE
Add OFN_DB_USERNAME and OFN_DB_PASSWORD env vars to app user

### DIFF
--- a/roles/unicorn_user/templates/defaults.j2
+++ b/roles/unicorn_user/templates/defaults.j2
@@ -18,3 +18,11 @@ SMTP_PASSWORD={{ smtp_password }}
 {% if mail_bcc is defined %}
   MAIL_BCC={{ mail_bcc }}
 {% endif %}
+
+{% if db_user is defined %}
+OFN_DB_USERNAME={{ db_user }}
+{% endif %}
+
+{% if db_password is defined %}
+OFN_DB_PASSWORD={{ db_password }}
+{% endif %}


### PR DESCRIPTION
This way we can provide different DB credentials for each environment without having to change any config file since now `config/database.yml` reads the env vars.

This allows me to have specific credentials for my LXC setup without having to edit config/database.yml` manually.

More importantly, this helps us remove the line

```
- { src: "postgresql.yml.j2", dest: "{{ config_path }}/database.yml" }
```

from `roles/app/tasks/main.yml` and rely on the app's database.yml only. This will address https://github.com/openfoodfoundation/ofn-install/issues/387