### PR TITLE
Enable use of nginx or postgres logging separately

### DIFF
--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -17,3 +17,5 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+
+enable_nginx_logging: true

--- a/roles/datadog/tasks/nginx_stats.yml
+++ b/roles/datadog/tasks/nginx_stats.yml
@@ -16,7 +16,6 @@
     name: 'dd-agent'
     groups: adm
     append: yes
-  when: enable_datadog_logging is defined
 
 - name: enable datadog nginx integration
   template:

--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -31,7 +31,15 @@
     mode: 0640
   become: yes
   notify: restart postgres
-  when: enable_datadog_logging is defined
+  when: enable_postgres_logging is defined
+
+- name: remove postgres logging configuration
+  file:
+    dest: "{{ postgresql_config_path }}/conf.d/logging.conf"
+    state: absent
+  become: yes
+  notify: restart postgres
+  when: enable_postgres_logging is undefined
 
 - name: get relations in openfoodnetwork's database
   command: "psql {{ db }} -tAc \"SELECT c.relname AS table_name

--- a/roles/datadog/templates/dd-nginx.j2
+++ b/roles/datadog/templates/dd-nginx.j2
@@ -7,7 +7,7 @@ instances:
     tags:
       - "host:{{ inventory_hostname }}"
 
-{% if enable_datadog_logging is defined %}
+{% if enable_nginx_logging is defined %}
 logs:
   - type: file
     path: /var/log/nginx/access.log

--- a/roles/datadog/templates/dd-postgres.j2
+++ b/roles/datadog/templates/dd-postgres.j2
@@ -16,7 +16,7 @@ instances:
       - "{{ relation }}"
     {% endfor %}
 
-{% if enable_datadog_logging is defined %}
+{% if enable_postgres_logging is defined %}
 logs:
   - type: file
     path: /var/log/pg_log/postgresql-*.log


### PR DESCRIPTION
Separates nginx and postgres logging via datadog so they can be enabled individually.