### PR TITLE
Enable Nginx log monitoring for FR and ES

### DIFF
--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -13,3 +13,5 @@ certbot_domains:
 certbot_cert_name: app.katuma.org
 
 swapfile_size: 2G
+
+enable_nginx_logging: true

--- a/inventory/host_vars/www.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/www.openfoodfrance.org/config.yml
@@ -15,3 +15,5 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+
+enable_nginx_logging: true


### PR DESCRIPTION
Closes #495 

This will send the Nginx logs to Datadog where they can be inspected an analyzed.