### PR TITLE
Use `preload_app` option for Unicorn memory improvements

### DIFF
--- a/roles/webserver/templates/unicorn.rb.j2
+++ b/roles/webserver/templates/unicorn.rb.j2
@@ -6,3 +6,20 @@ stdout_path "{{ unicorn_log }}"
 listen "{{ unicorn_sock }}"
 worker_processes {{ unicorn_workers }}
 timeout {{ unicorn_timeout }}
+
+# The following enables use of the Ruby 2.0+ Copy-On-Write feature
+# for more efficient memory usage in Unicorn workers.
+
+if ['production', 'staging'].include? ENV["RAILS_ENV"]
+  preload_app true
+
+  before_fork do |server, worker|
+    defined?(ActiveRecord::Base) and
+        ActiveRecord::Base.connection.disconnect!
+  end
+
+  after_fork do |server, worker|
+    defined?(ActiveRecord::Base) and
+        ActiveRecord::Base.establish_connection
+  end
+end


### PR DESCRIPTION
Closes #498 

Enables Unicorn's `preload_app` option, which should make Unicorn memory usage more efficient.

Tested and working :heavy_check_mark: 

I think we would need to put this on a server with Datadog metrics to properly analyse it.