### PR TITLE
Add `host_id` variable

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -27,6 +27,7 @@ l10n_git_version: HEAD
 #----------------------------------------------------------------------
 # Default values (should be overridden in each server config)
 rails_env: staging
+host_id: ofn-staging
 admin_email: "admin@{{ domain }}"
 
 

--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: example.com
+host_id: es-prod # country initials (eg uk, es, de) and environment (default is prod)
 rails_env: production
 
 admin_email: admin@example.com

--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -1,5 +1,6 @@
 ---
 domain: app.katuma.org
+host_id: es-prod
 rails_env: production
 
 admin_email: info@coopdevs.org

--- a/inventory/host_vars/local_travis/config.yml
+++ b/inventory/host_vars/local_travis/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: localhost
+host_id: vagrant-dev
 rails_env: development
 
 admin_email: admin@example.com

--- a/inventory/host_vars/openfoodireland.eu/config.yml
+++ b/inventory/host_vars/openfoodireland.eu/config.yml
@@ -1,3 +1,4 @@
 ---
 
 domain: openfoodireland.eu
+host_id: ie-prod

--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: openfoodnetwork.ca
+host_id: ca-prod
 rails_env: production
 
 admin_email: admin@openfoodnetwork.ca

--- a/inventory/host_vars/openfoodnetwork.de/config.yml
+++ b/inventory/host_vars/openfoodnetwork.de/config.yml
@@ -1,5 +1,6 @@
 ---
 domain: openfoodnetwork.de
+host_id: de-prod
 rails_env: production
 admin_email: admin@openfoodfoundation.org
 

--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: openfoodnetwork.net
+host_id: us-prod
 rails_env: production
 
 admin_email: ofn-usa@openfoodnetwork.net

--- a/inventory/host_vars/prod2.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/prod2.openfoodnetwork.org.au/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: openfoodnetwork.org.au
+host_id: au-prod
 rails_env: production
 
 admin_email: maikel@openfoodnetwork.org.au

--- a/inventory/host_vars/staging.katuma.org/config.yml
+++ b/inventory/host_vars/staging.katuma.org/config.yml
@@ -1,5 +1,6 @@
 ---
 domain: staging.katuma.org
+host_id: es-staging
 rails_env: staging
 admin_email: info@coopdevs.org
 

--- a/inventory/host_vars/staging.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/staging.openfoodfrance.org/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: staging.openfoodfrance.org
+host_id: fr-staging
 rails_env: staging
 
 admin_email: admin@openfoodfrance.org

--- a/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: staging.openfoodnetwork.org.au
+host_id: au-staging
 rails_env: staging
 
 admin_email: maikel@openfoodnetwork.org.au

--- a/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: staging.openfoodnetwork.org.uk
+host_id: uk-staging
 rails_env: staging
 
 admin_email: dev.ofnuk@gmail.com

--- a/inventory/host_vars/staging2.openfood.com.au/config.yml
+++ b/inventory/host_vars/staging2.openfood.com.au/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: staging2.openfoodnetwork.com.au
+host_id: au-staging
 rails_env: staging
 
 admin_email:

--- a/inventory/host_vars/staging2.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging2.openfoodnetwork.org.uk/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: staging2.openfoodnetwork.org.uk
+host_id: uk-staging
 rails_env: staging
 
 admin_email: dev.ofnuk@gmail.com

--- a/inventory/host_vars/www.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/www.openfoodfrance.org/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: www.openfoodfrance.org
+host_id: fr-prod
 rails_env: production
 
 admin_email: admin@openfoodfrance.org

--- a/inventory/host_vars/www.openfoodnetwork.be/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.be/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: www.openfoodnetwork.be
+host_id: be-prod
 rails_env: production
 
 admin_email: admin@openfoodnetwork.be

--- a/inventory/host_vars/www.openfoodnetwork.in/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.in/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: www.openfoodnetwork.in
+host_id: in-prod
 rails_env: production
 
 admin_email:

--- a/inventory/host_vars/www.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.au/config.yml
@@ -1,4 +1,5 @@
 ---
 
 domain: www.openfoodnetwork.org.au
+host_id: au-prod
 rails_env: production

--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -1,6 +1,7 @@
 ---
 
 domain: www.openfoodnetwork.org.uk
+host_id: uk-prod
 rails_env: production
 
 unicorn_workers: 4

--- a/inventory/host_vars/www.openfoodnetwork.org.za/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.za/config.yml
@@ -1,5 +1,6 @@
 ---
 domain: www.openfoodnetwork.org.za
+host_id: za-prod
 rails_env: production
 
 mail_domain: openfoodnetwork.org.za

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -29,7 +29,7 @@
           method: POST
           body:
             title: "Deployed"
-            text: "Successful deployment on host: {{ inventory_hostname }} ({{ ansible_limit }})"
+            text: "Successful deployment on host: {{ inventory_hostname }} ({{ host_id | default(ansible_limit) }})"
             host: "{{ inventory_hostname }}"
             tags:
               - "deployed"

--- a/playbooks/deploy_with_maintenance.yml
+++ b/playbooks/deploy_with_maintenance.yml
@@ -72,7 +72,7 @@
           method: POST
           body:
             title: "Deployed"
-            text: "Successful deployment on host: {{ inventory_hostname }} ({{ ansible_limit }})"
+            text: "Successful deployment on host: {{ inventory_hostname }} ({{ host_id | default(ansible_limit) }})"
             host: "{{ inventory_hostname }}"
             tags:
               - "deployed"

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -99,7 +99,7 @@
         method: POST
         body:
           title: "Provisioned"
-          text: "Provisioned host: {{ inventory_hostname }} ({{ ansible_limit }})"
+          text: "Provisioned host: {{ inventory_hostname }} ({{ host_id | default(ansible_limit) }})"
           host: "{{ inventory_hostname }}"
           tags:
             - "provisioned"

--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -8,7 +8,7 @@
       hostname: "{{ inventory_hostname }}"
       tags:
         - "env:{{ rails_env }}"
-        - "host-id:{{ ansible_limit }}"
+        - "host-id:{{ host_id | default(ansible_limit) }}"
       logs_enabled: true
   when: datadog_key is defined
 


### PR DESCRIPTION
Adds a simple `host_id` variable that can be used in Ansible tasks. We currently use `{{ ansible_limit }}` in some places to extract values like `es-prod`, but when using commands with groups like `--limit europe` this will fail.

It's really difficult (and messy) to accurately extract this value from the groups variables when a broader group is used, so we can just define it per-host.

It's really useful in things like Datadog where you want to apply a human-readable tag to metrics being sent from a host, as an identifier that can then be used for filtering.