### PR TITLE
APM in the uk

### DIFF
--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -19,3 +19,4 @@ custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 enable_nginx_logging: true
+enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -21,6 +21,8 @@ GOOGLE_MAPS_API_KEY: {{ google_maps_api_key }}
 ADMIN_EMAIL: {{ admin_email }}
 ADMIN_PASSWORD: {{ admin_password }}
 
+DATADOG_RAILS_APM: {{ enable_rails_apm | default('false') }}
+
 {% if s3_access_key is defined %}
 S3_ACCESS_KEY: {{ s3_access_key }}
 {% endif %}

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -21,8 +21,9 @@ GOOGLE_MAPS_API_KEY: {{ google_maps_api_key }}
 ADMIN_EMAIL: {{ admin_email }}
 ADMIN_PASSWORD: {{ admin_password }}
 
-DATADOG_RAILS_APM: {{ enable_rails_apm | default('false') }}
-
+{% if enable_rails_apm is defined %}
+DATADOG_RAILS_APM: {{ enable_rails_apm }}
+{% endif %}
 {% if s3_access_key is defined %}
 S3_ACCESS_KEY: {{ s3_access_key }}
 {% endif %}

--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -10,6 +10,10 @@
         - "env:{{ rails_env }}"
         - "host-id:{{ ansible_limit }}"
       logs_enabled: true
+      apm_enabled: "{{ enable_rails_apm | default('false') }}"
+    datadog_config_ex:
+      trace.config:
+        env: "{{ rails_env }}"
   when: datadog_key is defined
 
 - name: set up postgres stats collection


### PR DESCRIPTION
Part two of #496 

Depends on: https://github.com/openfoodfoundation/openfoodnetwork/pull/4151

The PR above has to be merged and deployed before using this one.

Adds optional use of Rails APM with Datadog.

Tested on UK Staging (and removed afterwards). :heavy_check_mark: 

![](https://cdn.shopify.com/s/files/1/1852/3415/products/Anarchy_poster_hvitt_530x@2x.jpg?v=1511466860)