### PR TITLE
Build Brotli module from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
     fi
 
 install:
-  - pip install 'ansible<2.7.0'
+  - pip install 'ansible==2.7.10'
   - pip install 'ansible-lint==4.1.0'
 
 script:

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -33,6 +33,9 @@ admin_email: "admin@{{ domain }}"
 #----------------------------------------------------------------------
 # security role variables
 security_autoupdate_mail_to: "{{ developer_email }}"
+security_autoupdate_blacklist:
+  - nginx
+  - nginx-common
 
 #----------------------------------------------------------------------
 # Database backup variables

--- a/roles/brotli_nginx/defaults/main.yml
+++ b/roles/brotli_nginx/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+
+nginx_brotli_version: v0.1.2
+nginx_modules_path: /etc/nginx/modules
+nginx_src_path: /usr/local/src/nginx
+nginx_brotli_src_path: /usr/local/src/ngx_brotli
+nginx_brotli_build_deps:
+  - nginx
+  - brotli
+  - dpkg-dev
+  - build-essential
+  - git
+  - libpcre3
+  - libpcre3-dev
+  - zlib1g
+  - zlib1g-dev
+  - openssl
+  - libssl-dev

--- a/roles/brotli_nginx/tasks/build.yml
+++ b/roles/brotli_nginx/tasks/build.yml
@@ -53,7 +53,7 @@
     nginx_build_args: "{{ nginx_config_args.stderr.split('configure arguments: ')[1] }}"
   changed_when: False
 
-- name: configure build
+- name: configure build # noqa 305
   shell: "./configure {{ nginx_build_args }} --with-compat --add-dynamic-module={{ nginx_brotli_src_path }}"
   args:
     chdir: "{{ nginx_src_path }}/nginx-{{ installed_nginx_version }}"
@@ -67,7 +67,7 @@
   register: nginx_modules_built
   become: yes
 
-- name: add brotli modules to nginx
+- name: add brotli modules to nginx # noqa 503
   copy:
     src: "{{ nginx_src_path }}/nginx-{{ installed_nginx_version }}/objs/{{ item }}"
     dest: "{{ nginx_modules_path }}/{{ item }}"

--- a/roles/brotli_nginx/tasks/build.yml
+++ b/roles/brotli_nginx/tasks/build.yml
@@ -1,0 +1,80 @@
+---
+
+- name: ensure official nginx repo
+  include_role:
+    name: jdauphant.nginx
+    tasks_from: nginx-official-repo.yml
+    apply:
+      become: yes
+
+- name: install build dependencies
+  apt:
+    name: "{{ nginx_brotli_build_deps }}"
+    state: present
+  become: yes
+
+- name: register nginx version
+  command: nginx -v
+  register: nginx_version_raw
+  changed_when: False
+
+- name: parse nginx version
+  set_fact:
+    installed_nginx_version: "{{ nginx_version_raw.stderr.split('nginx/')[1] }}"
+
+- name: create nginx source directory
+  file:
+    dest: "{{ nginx_src_path }}"
+    state: directory
+  become: yes
+
+- name: download and extract nginx source
+  unarchive:
+    src: "http://nginx.org/download/nginx-{{ installed_nginx_version }}.tar.gz"
+    dest: "{{ nginx_src_path }}"
+    remote_src: yes
+  become: yes
+
+- name: fetch brotli module source
+  git:
+    repo: https://github.com/eustas/ngx_brotli
+    dest: "{{ nginx_brotli_src_path }}"
+    version: "{{ nginx_brotli_version }}"
+    depth: 1
+  become: yes
+
+- name: get nginx config values
+  command: nginx -V
+  register: nginx_config_args
+  changed_when: False
+
+- name: extract nginx build args
+  set_fact:
+    nginx_build_args: "{{ nginx_config_args.stderr.split('configure arguments: ')[1] }}"
+  changed_when: False
+
+- name: configure build
+  shell: "./configure {{ nginx_build_args }} --with-compat --add-dynamic-module={{ nginx_brotli_src_path }}"
+  args:
+    chdir: "{{ nginx_src_path }}/nginx-{{ installed_nginx_version }}"
+    creates: "{{ nginx_src_path }}/nginx-{{ installed_nginx_version }}/Makefile"
+  become: yes
+
+- name: make brotli modules
+  make:
+    chdir: "{{ nginx_src_path }}/nginx-{{ installed_nginx_version }}"
+    target: modules
+  register: nginx_modules_built
+  become: yes
+
+- name: add brotli modules to nginx
+  copy:
+    src: "{{ nginx_src_path }}/nginx-{{ installed_nginx_version }}/objs/{{ item }}"
+    dest: "{{ nginx_modules_path }}/{{ item }}"
+    remote_src: yes
+  with_items:
+    - ngx_http_brotli_filter_module.so
+    - ngx_http_brotli_static_module.so
+  when: nginx_modules_built.changed
+  become: yes
+  notify: reload nginx

--- a/roles/brotli_nginx/tasks/fix.yml
+++ b/roles/brotli_nginx/tasks/fix.yml
@@ -1,0 +1,17 @@
+---
+# This can be removed after all servers have been provisioned
+
+- name: remove previously added brotli ppa (if present)
+  apt_repository:
+    repo: ppa:hda-me/nginx-stable
+    state: absent
+  register: brotli_remove_ppa
+  become: yes
+
+- name: ensure official nginx version
+  apt:
+    name: nginx=1.16.1-1*
+    force: yes
+  when: brotli_remove_ppa.changed
+  become: yes
+  notify: restart nginx

--- a/roles/brotli_nginx/tasks/fix.yml
+++ b/roles/brotli_nginx/tasks/fix.yml
@@ -8,7 +8,7 @@
   register: brotli_remove_ppa
   become: yes
 
-- name: ensure official nginx version
+- name: ensure official nginx version # noqa 503
   apt:
     name: nginx=1.16.1-1*
     force: yes

--- a/roles/brotli_nginx/tasks/main.yml
+++ b/roles/brotli_nginx/tasks/main.yml
@@ -1,10 +1,7 @@
 ---
 
-- name: remove previously added brotli ppa (if present)
-  apt_repository:
-    repo: ppa:hda-me/nginx-stable
-    state: absent
-  become: yes
+- name: fix nginx packages
+  include_tasks: fix.yml
 
 - name: build brotli nginx module from source
   include_tasks: build.yml

--- a/roles/brotli_nginx/tasks/main.yml
+++ b/roles/brotli_nginx/tasks/main.yml
@@ -1,12 +1,10 @@
 ---
 
-- name: add brotli ppa
+- name: remove previously added brotli ppa (if present)
   apt_repository:
     repo: ppa:hda-me/nginx-stable
+    state: absent
   become: yes
 
-- name: install brotli
-  apt:
-    name: [brotli, nginx-module-brotli]
-    state: present
-  become: yes
+- name: build brotli nginx module from source
+  include_tasks: build.yml


### PR DESCRIPTION
Closes #504 

- Builds Brotli module from source instead of installing from ppa
- Fixes issues caused by the previous Brotli ppa (US and France)
- Avoids nginx auto-update issues

Tested in Vagrant, French Staging, and Katuma Staging.