### PR TITLE
Rotate Rails and (Datadog) Postgres Query logs

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -22,3 +22,6 @@
 
 - src: libre_ops.wal2json
   version: 1.0.2
+
+- src: arillso.logrotate
+  version: 1.4.5

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -135,10 +135,9 @@ logrotate_applications:
       - logs:
           - "{{ current_path }}/log/*.log"
         options:
-          - daily         # rotate daily
-          - rotate 14     # delete logs older than 14 rotations
+          - weekly        # rotate weekly
+          - rotate 4     # delete logs older than 4 rotations
           - compress      # compress rotated logs
-          - delaycompress # wait a day before compressing last rotated log
           - missingok     # ignore missing logs
           - notifempty    # don't rotate if empty
           - copytruncate  # copy the log, then empty the active logfile

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -127,6 +127,34 @@ l10n_path: "{{ shared_path }}/l10n"
 
 
 #----------------------------------------------------------------------
+# Logrotate options
+
+logrotate_applications:
+  - name: rails
+    definitions:
+      - logs:
+          - "{{ current_path }}/log/*.log"
+        options:
+          - daily         # rotate daily
+          - rotate 14     # delete logs older than 14 rotations
+          - compress      # compress rotated logs
+          - delaycompress # wait a day before compressing last rotated log
+          - missingok     # ignore missing logs
+          - notifempty    # don't rotate if empty
+          - copytruncate  # copy the log, then empty the active logfile
+
+  - name: postgres_queries
+    definitions:
+      - logs:
+          - "/var/log/pg_log/*.log"
+        options:
+          - daily         # run daily
+          - rotate 0      # don't rotate files
+          - nocreate      # don't replace log files
+        lastaction:       # delete log files older than 1 day
+          - "find /var/log/pg_log/ -name '*.log' -mtime +1 -exec rm {};"
+
+#----------------------------------------------------------------------
 # Unicorn variables
 # User name for the unprivileged user which runs unicorn
 unicorn_user: openfoodnetwork

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -82,6 +82,10 @@
       become: yes
       tags: datadog
 
+    - role: arillso.logrotate
+      become: yes
+      tags: logrotate
+
   tasks:
     - meta: flush_handlers # Ensure handlers run successfully before reporting success
 


### PR DESCRIPTION
Closes #503 and https://github.com/openfoodfoundation/ofn-install/issues/96

Adds central management of logrotate rules.

This should help a bit when investigating issues, and will help clean up bloated and outdated logs. 

We can extend the logrotate rules from this central point any time we need to regularly clean up any kind of files.