### PR TITLE
Remove Skylight

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -34,9 +34,6 @@ stripe_instance_secret_key: # sk_xxxx
 stripe_instance_publishable_key: # pk_xxxx
 stripe_endpoint_secret: # whsec_xxxx
 
-# Skylight's API key. This enables performance instrumentation through Skylight. See https://github.com/openfoodfoundation/openfoodnetwork/pull/2070 for details.
-#skylight_authentication: ""
-
 # Mail settings
 mail_host:
 mail_port:

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -15,6 +15,9 @@
 
       - meta: flush_handlers # Ensure handlers run successfully before reporting success
 
+      - include_role:
+          name: skylight_uninstaller
+
       - name: Notify Slack of successful deployment
         slack:
           token: "T02G54U79/BF25P9F7A/DJdtYaLLUpRJPiu72d8NqgGg"

--- a/roles/skylight_uninstaller/tasks/main.yml
+++ b/roles/skylight_uninstaller/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: get agent PID
+  shell: "set -o pipefail && ps -ef | grep -v grep | grep -w skylightd | awk '{print $2}'"
+  args:
+    executable: /bin/bash
+  ignore_errors: yes
+  register: skylight_agent_pid
+  changed_when: false
+  become: yes
+
+- name: kill agent
+  command: "kill {{ skylight_agent_pid.stdout }}"
+  when: skylight_agent_pid.stdout | length > 0
+  become: yes
+
+- name: wait for process to die
+  wait_for:
+    path: "/proc/{{ skylight_agent_pid.stdout }}/status"
+    state: absent
+  with_items: "{{ skylight_agent_pid.stdout }}"
+  become: yes
+  ignore_errors: yes
+  register: result
+
+- name: force kill stuck process
+  command: "kill -9 {{ skylight_agent_pid.stdout }}"
+  when: result is failed
+  become: yes
+
+- name: remove log file
+  file:
+    state: absent
+    path: "{{ app_path }}/current/log/skylight.log"

--- a/roles/unicorn_user/templates/defaults.j2
+++ b/roles/unicorn_user/templates/defaults.j2
@@ -1,9 +1,5 @@
 RAILS_ENV={{ rails_env }}
 
-{% if skylight_authentication is defined %}
-  SKYLIGHT_AUTHENTICATION={{ skylight_authentication }}
-{% endif %}
-
 MAIL_DOMAIN={{ mail_domain }}
 MAIL_HOST={{ mail_host }}
 MAIL_PORT={{ mail_port }}

--- a/roles/webserver/templates/unicorn.service.j2
+++ b/roles/webserver/templates/unicorn.service.j2
@@ -9,10 +9,6 @@ User=openfoodnetwork
 WorkingDirectory={{ current_path }}
 Environment=RAILS_ENV={{ rails_env }}
 
-{% if skylight_authentication is defined %}
-  Environment=SKYLIGHT_AUTHENTICATION={{ skylight_authentication }}
-{% endif %}
-
 SyslogIdentifier=openfoodnetwork-unicorn
 PIDFile={{ unicorn_pid }}
 


### PR DESCRIPTION
## What

Since we adopted Skylight to get response times across endpoints and
instances, we failed to get accurate numbers. Our Rails version is not
supported and thus Skylight fails to provide data for the slowest
endpoints, the ones we care about the most. Even with a supported one, we
could potentially hit any limits on tracing and have the same problem.

Recently, we started paying for Datadog's APM and the experience,
although it's still early, has been better. It makes it possible to
correlate between services and other metrics which helps to spot the
underlying issues.

Therefore, having two agents running on the server consumes system
resources so we better get rid of Skylight's one.