### PR TITLE
Enable remote access from Metabase to Katuma's DB

### DIFF
--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -16,3 +16,9 @@ certbot_cert_name: app.katuma.org
 swapfile_size: 2G
 
 enable_nginx_logging: true
+
+postgres_listen_addresses:
+  - '*'
+
+custom_hba_entries:
+  - { type: hostssl, database: "{{ db }}", user: metabase, address: '167.99.89.242/32', auth_method: md5 }


### PR DESCRIPTION
This makes it possible to execute queries from Metabase against Katuma's
production DB, as a first towards a global Business Intelligence tool
while allowing Katuma to bill its customers reliably.

This enables us to start collecting the pricing for each of the currently active hubs and producers and start charging them reliably.

Next step will be to use https://github.com/openfoodfoundation/ofn-data data streaming.