### PR TITLE
Ruby bump: ofn-install edition

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   config.vm.provider :virtualbox do |vbox|
-    config.vm.box = "ubuntu/bionic64"
+    config.vm.box = "ubuntu/xenial64"
 
     # Set box memory.
     vbox.customize ["modifyvm", :id, "--memory", "2500"]
@@ -32,5 +32,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.ssh.insert_key = false
   end
-
 end

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -51,7 +51,7 @@ swapfile_size: false
 
 #----------------------------------------------------------------------
 # Rails variables
-ruby_version: 2.1.5
+ruby_version: 2.1.9
 env:
   RAILS_ENV: "{{ rails_env }}"
   PATH: "{{ gem_home }}/bin:{{ ansible_env.PATH }}"

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -34,6 +34,19 @@
     - { src: "{{ l10n_path }}/states.yml", dest: "{{ build_path }}/db/default/spree/states.yml" }
   tags: symlink
 
+# Ensure the correct Ruby version is activated for this build
+
+- name: register ruby version in new build
+  slurp:
+    src: "{{ build_path }}/.ruby-version"
+  register: deploy_ruby_version
+  become: yes
+
+- name: use ruby {{ deploy_ruby_version['content'] | b64decode | trim }}
+  shell: bash -lc "{{ unicorn_home_path }}/.rbenv/bin/rbenv global {{ deploy_ruby_version['content'] | b64decode | trim }} && rbenv rehash"
+  become: yes
+  become_user: "{{ unicorn_user }}"
+
 # Install bundler and gems
 
 - name: install bundler


### PR DESCRIPTION
Related to https://github.com/openfoodfoundation/openfoodnetwork/pull/4250

Provisions servers with Ruby `2.1.9`. 

The old Ruby `2.1.5` and associated gems will remain on the servers. We can tidy them up later by setting `rbenv_clean_up: true`.

### Testing:

- [x] Run `provision.yml` with these changes
- [x] Make sure Ruby `2.1.9` can be built without errors
- [x] Deploy https://github.com/openfoodfoundation/openfoodnetwork/pull/4250
- [x] Test everything is ok
- [x] Check pre-2.1.9 branches can still be deployed. 

### Ops:
- [ ] Merge this PR
- [ ] Provision all instances, including Staging servers
- [x] Merge https://github.com/openfoodfoundation/openfoodnetwork/pull/4250
- [ ] Make sure Semaphore is set to build with `2.1.9` 