### PR TITLE
Add memcached monitoring to Datadog

### DIFF
--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -24,6 +24,10 @@
   import_tasks: nginx_stats.yml
   when: datadog_key is defined
 
+- name: set up memcached stats collection
+  import_tasks: memcached_stats.yml
+  when: datadog_key is defined
+
 - name: disable datadog agent
   service:
     name: datadog-agent

--- a/roles/datadog/tasks/memcached_stats.yml
+++ b/roles/datadog/tasks/memcached_stats.yml
@@ -1,0 +1,11 @@
+---
+
+- name: enable datadog memcached integration
+  template:
+    src: dd-memcached.j2
+    dest: /etc/datadog-agent/conf.d/mcache.d/conf.yaml
+    owner: 'dd-agent'
+    group: 'dd-agent'
+    mode: 0644
+  become: true
+  notify: restart datadog-agent

--- a/roles/datadog/templates/dd-memcached.conf.j2
+++ b/roles/datadog/templates/dd-memcached.conf.j2
@@ -1,0 +1,12 @@
+---
+
+init_config:
+
+instances:
+  - url: localhost
+    tags:
+      - "host:{{ inventory_hostname }}"
+
+    options:
+      items: true
+      slabs: true


### PR DESCRIPTION
Closes #515 

Adds `memcached` monitoring to instances that use Datadog.