### PR TITLE
Allow Zapier user access to Postgres for USA

### DIFF
--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -19,3 +19,9 @@ mail_domain: openfoodnetwork.net
 # Size in bytes. You can also use units like 1G, 512MiB or 1000KB. See: `man fallocate`
 # The default is `false`, not installing a swapfile.
 swapfile_size: 1G
+
+postgres_listen_addresses:
+  - '*'
+
+custom_hba_entries:
+  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }


### PR DESCRIPTION
Part 2 of: https://github.com/openfoodfoundation/ofn-install/issues/513

Allows Zapier access to Postgres and sets Postgres to listen for external connections (for the Zapier IP only).