### PR TITLE
Enable Datadog's APM in UK staging

### DIFF
--- a/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
@@ -7,3 +7,5 @@ rails_env: staging
 admin_email: dev.ofnuk@gmail.com
 
 unicorn_timeout: 120
+
+enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug

--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -10,7 +10,8 @@
         - "env:{{ rails_env }}"
         - "host-id:{{ host_id | default(ansible_limit) }}"
       logs_enabled: true
-      apm_enabled: "{{ enable_rails_apm | default('false') }}"
+      apm_config:
+        enabled: "{{ enable_rails_apm | default('false') }}"
     datadog_config_ex:
       trace.config:
         env: "{{ rails_env }}"


### PR DESCRIPTION
We need to be able to test changes in monitoring quickly and reliably without having to risk production. This will incur an extra cost but it'll save money in dev hours testing things in the long run.