### PR TITLE
Remove ZA from all-prod group

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -161,7 +161,6 @@ us-prod
 europe
 america
 au-prod
-za-prod
 
 #------------------------------------------------------------------------------
 # Staging Servers


### PR DESCRIPTION
ofn-secrets does not include its secrets.yml yet so commands would fail for the ZA server.