### PR TITLE
Increase max size of cache entries so products cache can be larger than the default 1MB

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -164,6 +164,9 @@ unicorn_sock: "{{ sock_path }}/unicorn.{{ app }}.sock"
 unicorn_workers: 2
 unicorn_timeout: 30
 
+#----------------------------------------------------------------------
+# Memcached variables
+memcached_value_max_megabytes: 4
 
 #----------------------------------------------------------------------
 # Core devs: users named here will have SSH access on all instances

--- a/roles/common/templates/memcached.conf.j2
+++ b/roles/common/templates/memcached.conf.j2
@@ -47,4 +47,4 @@ logfile /var/log/memcached.log
 -t 6
 
 # Increase max of size of cache entries # 10M will contain around 2k products
--I 4M
+-I {{ memcached_value_max_megabytes }}M

--- a/roles/common/templates/memcached.conf.j2
+++ b/roles/common/templates/memcached.conf.j2
@@ -45,3 +45,6 @@ logfile /var/log/memcached.log
 
 # Increase number of threads from default of 4
 -t 6
+
+# Increase max of size of cache entries # 10M will contain around 2k products
+-I 4M

--- a/roles/unicorn_user/templates/defaults.j2
+++ b/roles/unicorn_user/templates/defaults.j2
@@ -26,3 +26,5 @@ OFN_DB_USERNAME={{ db_user }}
 {% if db_password is defined %}
 OFN_DB_PASSWORD={{ db_password }}
 {% endif %}
+
+MEMCACHED_VALUE_MAX_MEGABYTES={{ memcached_value_max_megabytes }}


### PR DESCRIPTION
### Description

- Related to #4256

In bug [#4256](https://github.com/openfoodfoundation/openfoodnetwork/issues/4256) 447 products were taking 1MB of space. We need to change max size of cache values to 4MB so we can handle at least 2k products.

This problem will need to be addressed differently when the product list is paginated. We will probably be able to revert this change as each page will never take more than 1MB.

This PR takes care of configuring the memcached server to use 4 MB. The memcached client library, which in this case is `dalli`, also needs to be configured to allow storing values up to this size - this is done in https://github.com/openfoodfoundation/openfoodnetwork/pull/4356.

This PR is best to be provisioned and tested with this PR's branch deployed: https://github.com/openfoodfoundation/openfoodnetwork/pull/4356

#### Testing

See details of test I did in `es-staging` [here](https://github.com/openfoodfoundation/openfoodnetwork/pull/4356#issuecomment-539461736).