### PR TITLE
Make assets precompile tasks always clean assets before

### DIFF
--- a/roles/shared_handlers/handlers/main.yml
+++ b/roles/shared_handlers/handlers/main.yml
@@ -1,6 +1,6 @@
 # This role holds reusable handlers that can be included in multiple playbooks to keep things DRY
 - name: precompile assets
-  command: bash -lc "bundle exec rake assets:precompile:primary RAILS_GROUPS=assets RAILS_ENV={{ rails_env }}"
+  command: bash -lc "bundle exec rake assets:clean assets:precompile:primary RAILS_GROUPS=assets RAILS_ENV={{ rails_env }}"
   args:
     chdir: "{{ current_path }}"
   become: yes


### PR DESCRIPTION
#### What? Why?
Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/4328 

Cleaning assets before precompiling assets make translations always being updated, even if JS code is not updated.

Maybe there's some i18n-js config we could change to achieve this but I have not managed to find it.

#### What should we test?
I tested this PR and the problem is fixed because a new JS bundle is always generated.
Maybe another dev can verify the process again in staging. Or we can just deploy 2.5.2 again to FR live and see if the problem is fixed, it's harmless.

#### Release notes
Changelog Category: Fixed
Translations stored in the browser (Javascript) are now always updated even if no code changes on the javascript side.