### PR TITLE
Make Canada's server to use en_CA

### DIFF
--- a/inventory/group_vars/ca.yml
+++ b/inventory/group_vars/ca.yml
@@ -4,8 +4,8 @@
 checkout_zone: Canada
 country_code: CA
 currency: CAD
-locale: en
-available_locales: en,fr_CA    # Available locales for OFN instance
+locale: en_CA
+available_locales: en_CA,fr_CA    # Available locales for OFN instance
 language: en.UTF-8       # Default language for the server
 language_packages:          # Language packages for the server
   - language-pack-en-base


### PR DESCRIPTION
Canada's server is using en. This makes it use en_CA.

We may want to run the following SQL on the server after deploy so that all users will immeditely see this language:
update spree_users set locale = 'en_CA' where locale = 'en';