### PR TITLE
Change en to en_DE on the german instance

### DIFF
--- a/inventory/group_vars/de.yml
+++ b/inventory/group_vars/de.yml
@@ -4,7 +4,7 @@ checkout_zone: Europe
 country_code: DE
 currency: EUR
 locale: de_DE
-available_locales: de_DE,en
+available_locales: de_DE,en_DE
 language: de_DE.UTF-8
 language_packages:
   - language-pack-de-base


### PR DESCRIPTION
As requested by Kirsten.

This needs the new language en_DE to be added to the main ofn repo first.