### PR TITLE
Increase timeouts for French production

### DIFF
--- a/inventory/host_vars/www.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/www.openfoodfrance.org/config.yml
@@ -8,7 +8,7 @@ admin_email: admin@openfoodfrance.org
 
 mail_domain: openfoodfrance.org
 
-unicorn_timeout: 120
+unicorn_timeout: 240
 unicorn_workers: 4
 
 postgres_listen_addresses:


### PR DESCRIPTION
Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/4439

Increases timeouts on French prod from 120 to 240. 

This is due to `Orders and Fulfilment` reports timing out. These should be fixed soon :crossed_fingers: so this is a temporary measure.