### PR TITLE
Add en_FR as available locale on french instance

### DIFF
--- a/inventory/group_vars/fr.yml
+++ b/inventory/group_vars/fr.yml
@@ -5,7 +5,7 @@ checkout_zone: Europe
 country_code: FR
 currency: EUR
 locale: fr
-available_locales: fr,it
+available_locales: fr,it,en_FR
 language: en_US.UTF-8
 language_packages:
   - language-pack-en-base


### PR DESCRIPTION
As requested by instance manager.

en_FR.yml is already merged through https://github.com/openfoodfoundation/openfoodnetwork/pull/4440