### PR TITLE
Provision Ruby 2.3.8

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -52,6 +52,11 @@ swapfile_size: false
 #----------------------------------------------------------------------
 # Rails variables
 ruby_version: 2.3.8
+
+ruby_versions:
+  - version: 2.2.10
+  - version: 2.3.8
+
 env:
   RAILS_ENV: "{{ rails_env }}"
   PATH: "{{ gem_home }}/bin:{{ ansible_env.PATH }}"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -51,7 +51,7 @@ swapfile_size: false
 
 #----------------------------------------------------------------------
 # Rails variables
-ruby_version: 2.2.10
+ruby_version: 2.3.8
 env:
   RAILS_ENV: "{{ rails_env }}"
   PATH: "{{ gem_home }}/bin:{{ ansible_env.PATH }}"

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -55,8 +55,7 @@
         env: user
         version: v1.0.0
         default_ruby: "{{ ruby_version }}"
-        rubies:
-          - version: "{{ ruby_version }}"
+        rubies: "{{ ruby_versions }}"
 
       rbenv_users:
         - "{{ unicorn_user }}"


### PR DESCRIPTION
- Installs Ruby `2.3.8`
- Ensures previous version (`2.2.10`) is installed, for smoother testing process in CI builds