### PR TITLE
Increase uk timeout to 720secs

### DIFF
--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -5,7 +5,7 @@ host_id: uk-prod
 rails_env: production
 
 unicorn_workers: 4
-unicorn_timeout: 360
+unicorn_timeout: 720
 
 swapfile_size: 1G
 


### PR DESCRIPTION
Increase Uk timeout to make reports run.
This has been provisioned to uk and the reports now work after 7mins.

Fixes https://github.com/openfoodfoundation/openfoodnetwork/issues/4521