### PR TITLE
Disable Datadog in Katuma staging

### DIFF
--- a/inventory/host_vars/staging.katuma.org/config.yml
+++ b/inventory/host_vars/staging.katuma.org/config.yml
@@ -5,3 +5,5 @@ rails_env: staging
 admin_email: info@coopdevs.org
 
 mail_domain: katuma.org
+
+disable_datadog: true


### PR DESCRIPTION
I thought this was disabled long ago but Datadog was still monitoring
the infrastructure (that the minimum service they provide when no APM is
enabled). It turns out only this flag stops the stats collection daemon.

This should lower the monthly bill a little bit.