### PR TITLE
Allow setting an alternate region for S3 backups bucket

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -20,9 +20,10 @@ google_maps_api_key:
 # Set these if using Amazon S3
 #s3_access_key:
 #s3_secret:
-#s3_region:
 #s3_images_bucket:
+#s3_region:
 #s3_backups_bucket:
+#s3_backups_region:
 
 # Stripe Connect API keys
 # Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -33,6 +33,9 @@ S3_SECRET: {{ s3_secret }}
 {% if s3_region is defined %}
 S3_REGION: {{ s3_region }}
 {% endif %}
+{% if s3_backups_region is defined %}
+S3_BACKUPS_REGION: {{ s3_backups_region }}
+{% endif %}
 {% if s3_backups_bucket is defined %}
 S3_BACKUPS_BUCKET: {{ s3_backups_bucket }}
 {% endif %}


### PR DESCRIPTION
Twinned with https://github.com/openfoodfoundation/openfoodnetwork/pull/4653

Allows setting an alternate region for S3 backups bucket.