### PR TITLE
Move Datadog APM from UK to France

### DIFF
--- a/inventory/host_vars/www.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/www.openfoodfrance.org/config.yml
@@ -18,3 +18,4 @@ custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 enable_nginx_logging: true
+enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug

--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -20,4 +20,3 @@ custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 enable_nginx_logging: true
-enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug


### PR DESCRIPTION
Closes #544 

Moves APM from UK to France in preparation for the datastreaming trial.
