### PR TITLE
Add non-www support for certbot in fr-prod

### DIFF
--- a/inventory/host_vars/www.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/www.openfoodfrance.org/config.yml
@@ -11,6 +11,10 @@ mail_domain: openfoodfrance.org
 unicorn_timeout: 240
 unicorn_workers: 4
 
+certbot_domains:
+  - www.openfoodfrance.org
+  - openfoodfrance.org
+
 postgres_listen_addresses:
   - '*'
 


### PR DESCRIPTION
This should resolve the certificate issue when accessing https://openfoodfrance.org. Right now, only www.openfoodfrance.org is supported.

Through curl:

```shell
$ curl https://openfoodfrance.org
curl: (51) SSL: no alternative certificate subject name matches target host name 'openfoodfrance.org'
```

From the browser, I get `NET::ERR_CERT_COMMON_NAME_INVALID`.