### PR TITLE
Increase swap space for au-prod

### DIFF
--- a/inventory/host_vars/prod2.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/prod2.openfoodnetwork.org.au/config.yml
@@ -17,7 +17,7 @@ certbot_domains:
 
 # Size in bytes. You can also use units like 1G, 512MiB or 1000KB. See: `man fallocate`
 # The default is `false`, not installing a swapfile.
-swapfile_size: 1G
+swapfile_size: 8G
 
 unicorn_timeout: 360
 unicorn_workers: 3


### PR DESCRIPTION
A report is using more than 4GB of memory to be generated. This should
increase the likelyhood that it's successful without crashing anything.

It's a difficult balance because too much swap can just slow down the
server until it's not reacting any more. -> Trial and error.