### PR TITLE
Disable Datadog in stagings to save money

### DIFF
--- a/inventory/host_vars/staging.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/staging.openfoodfrance.org/config.yml
@@ -9,3 +9,5 @@ admin_email: admin@openfoodfrance.org
 mail_domain: openfoodfrance.org
 
 unicorn_timeout: 120
+
+disable_datadog: true

--- a/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
@@ -8,4 +8,4 @@ admin_email: dev.ofnuk@gmail.com
 
 unicorn_timeout: 120
 
-enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug
+disable_datadog: true


### PR DESCRIPTION
Last bill was $183.16 covering Datadog January 2020: 3 Commited Hosts
@ $54.00, 3 On-Demand Hosts @ $54.00, 2 On-Demand APM Hosts @ $72.00,
1.239 On-Demand Log Events (millions) @ $3.16.

This change should save us $90 every month, not a whole lot but we're
not checking staging's metrics. We can enable it temporally when
changing Datadog's config and disable it back again.