### PR TITLE
Remove AU production server from the prod list

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -160,7 +160,6 @@ us-prod
 [all-prod:children]
 europe
 america
-au-prod
 
 #------------------------------------------------------------------------------
 # Staging Servers


### PR DESCRIPTION
We want to avoid deploying to it by mistake until the reliability issues are not fixed yet. We experienced weird issues that we managed to fix when deploying v2.7.4 and finally decided to roll it back to v2.7.3.

It's very likely that any new deploy will screw things up. Better to avoid it.