### PR TITLE
Don't build Ruby twice in every build

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -54,7 +54,6 @@ swapfile_size: false
 ruby_version: 2.3.7
 
 ruby_versions:
-  - version: 2.2.10
   - version: 2.3.7
 
 env:


### PR DESCRIPTION
We've settled on Ruby 2.3.7 now, we don't need to spend an extra 10 minutes in each CI run (or new deployment) building Ruby 2.2.10 as well :rocket: