### PR TITLE
Avoid mistakenly deploying master to production due to minor typos

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -9,6 +9,15 @@
     - include: ../roles/shared_handlers/handlers/main.yml
 
   tasks:
+    - name: Check we're not deploying master to production
+      pause:
+        prompt: |
+          WARNING: The current settings will deploy `master` branch to a production server!
+          Check for typos in the command if deploying a release, otherwise type YES to proceed
+      when: inventory_hostname in groups['all-prod'] and git_version == "master"
+      register: deployment_check
+      failed_when: deployment_check.user_input != "YES"
+
     - block:
       - include_role:
           name: deploy


### PR DESCRIPTION
Now if you don't type the command correctly when deploying a release on a production server, you'll see this prompt _before_ the playbook runs, instead of realising after the playbook has finished that you've accidentally deployed `master` to production because of a typo... :see_no_evil: : 

![deploying_master](https://user-images.githubusercontent.com/9029026/74837273-6adb3b00-5321-11ea-99d7-5c07a5142016.png)

:muscle: :muscle: :muscle: 