### PR TITLE
Bump certbot_nginx role

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -9,7 +9,7 @@
   version: v2.8.1
 
 - src: coopdevs.certbot_nginx
-  version: 0.0.4
+  version: v0.1.0
 
 - src: oefenweb.swapfile
   version: v2.0.14


### PR DESCRIPTION
Related to #571 

Bumps the `certbot_nginx` role. 

This update includes a patch I submitted that allows certificates to be regenerated when the configs have changed.

This means if we update the certificate configs for a server, for example with France where it previously only had `www.openfoodfrance.org` in the list of domains but we have added the bare domain `openfoodfrance.org` to the list, we can use the following Ansible command to recreate the certificate with the updated configuration (the default behaviour is to ignore it if a certificate is already present):

`ansible-playbook playbooks/provision.yml --limit fr-prod --tags certbot -e "certbot_force_update=true"`