### PR TITLE
Precompiling in Rails 4

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -111,19 +111,8 @@
 
 # Precompile assets
 
-- name: precompile assets # noqa 301
-  command: bash -lc "bundle exec rake assets:clean assets:precompile:primary RAILS_GROUPS=assets RAILS_ENV={{ rails_env }}"
-  args:
-    chdir: "{{ build_path }}"
-  become: yes
-  become_user: "{{ unicorn_user }}"
-
-- name: precompile nondigest assets # noqa 301
-  command: bash -lc "bundle exec rake assets:precompile:nondigest RAILS_GROUPS=assets RAILS_ENV={{ rails_env }}"
-  args:
-    chdir: "{{ build_path }}"
-  become: yes
-  become_user: "{{ unicorn_user }}"
+- name: precompile assets
+  import_tasks: precompile.yml
 
 # Move new build into place
 

--- a/roles/deploy/tasks/precompile.yml
+++ b/roles/deploy/tasks/precompile.yml
@@ -1,0 +1,15 @@
+---
+
+- name: precompile assets # noqa 301
+  command: bash -lc "bundle exec rake assets:clean assets:precompile:primary RAILS_GROUPS=assets RAILS_ENV={{ rails_env }}"
+  args:
+    chdir: "{{ build_path }}"
+  become: yes
+  become_user: "{{ unicorn_user }}"
+
+- name: precompile nondigest assets # noqa 301
+  command: bash -lc "bundle exec rake assets:precompile:nondigest RAILS_GROUPS=assets RAILS_ENV={{ rails_env }}"
+  args:
+    chdir: "{{ build_path }}"
+  become: yes
+  become_user: "{{ unicorn_user }}"

--- a/roles/deploy/tasks/precompile.yml
+++ b/roles/deploy/tasks/precompile.yml
@@ -1,11 +1,24 @@
 ---
 
+- name: check rails version in Gemfile
+  shell: |
+    grep -x -m 1 -F "gem 'rails', '~> 3.2.22'" Gemfile
+  args:
+    chdir: "{{ build_path }}"
+    executable: /bin/bash
+  changed_when: False
+  ignore_errors: yes
+  register: check_rails_3
+
+# Precompile assets in Rails 3
+
 - name: precompile assets # noqa 301
   command: bash -lc "bundle exec rake assets:clean assets:precompile:primary RAILS_GROUPS=assets RAILS_ENV={{ rails_env }}"
   args:
     chdir: "{{ build_path }}"
   become: yes
   become_user: "{{ unicorn_user }}"
+  when: check_rails_3 is success
 
 - name: precompile nondigest assets # noqa 301
   command: bash -lc "bundle exec rake assets:precompile:nondigest RAILS_GROUPS=assets RAILS_ENV={{ rails_env }}"
@@ -13,3 +26,14 @@
     chdir: "{{ build_path }}"
   become: yes
   become_user: "{{ unicorn_user }}"
+  when: check_rails_3 is success
+
+# Precompile assets in Rails 4
+
+- name: precompile assets # noqa 301
+  command: bash -lc "bundle exec rake assets:precompile RAILS_ENV={{ rails_env }}"
+  args:
+    chdir: "{{ build_path }}"
+  become: yes
+  become_user: "{{ unicorn_user }}"
+  when: check_rails_3 is failure


### PR DESCRIPTION
Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/4819

Precompiling assets looks a bit different in Rails 4, it's one task instead of two, and the syntax is changed. 

This PR runs slightly different precompile tasks during deployments, based on a quick check in the Gemfile to see if Rails 3 is being used.