### PR TITLE
Add configs for using lexi (dev testing with LXD)

### DIFF
--- a/.lexi/container.yml
+++ b/.lexi/container.yml
@@ -1,0 +1,5 @@
+# Lexi container config
+container: ofn-install
+image: ubuntu:16.04
+default_user: ofn-admin
+container_ip: 10.10.100.10

--- a/.lexi/network.yml
+++ b/.lexi/network.yml
@@ -1,0 +1,13 @@
+version: 1
+config:
+  - type: physical
+    name: eth0
+    subnets:
+      - type: static
+        ipv4: true
+        address: $LEXI_CONTAINER_IP
+        netmask: 255.255.255.0
+        gateway: $LEXI_CONTAINER_GATEWAY
+        control: auto
+  - type: nameserver
+    address: 8.8.8.8

--- a/.lexi/users.yml
+++ b/.lexi/users.yml
@@ -1,0 +1,5 @@
+#cloud-config
+users:
+  - name: root
+    ssh-authorized-keys:
+      - $LEXI_SSH_KEY

--- a/inventory/group_vars/lexi.yml
+++ b/inventory/group_vars/lexi.yml
@@ -1,0 +1,17 @@
+---
+
+# See https://github.com/openfoodfoundation/ofn-install/wiki/Setup for more info
+checkout_zone: Australia
+country_code: AU
+currency: AUD
+locale: en
+language: en_AU.UTF-8
+language_packages:
+  - language-pack-en-base
+l10n_repo: https://github.com/openfoodfoundation/l10n_au.git
+timezone: Melbourne
+
+developer_email: admin@example.com
+
+users_sysadmin:
+  - "{{ core_devs }}"

--- a/inventory/host_vars/local_lexi/config.yml
+++ b/inventory/host_vars/local_lexi/config.yml
@@ -1,0 +1,18 @@
+---
+
+domain: localhost
+rails_env: development
+
+admin_email: admin@example.com
+mail_domain: example.com
+
+# Add missing vars to emulate secrets.yml
+db_password: 'lexi123'
+admin_password: 'spree123'
+secret_token: '511a3d0fa1551b9fa75a1aef5b47684905c64807963fa2c190272878366365'
+google_maps_api_key: 'xxx'
+
+mail_host: 'example.com'
+mail_port: 25
+smtp_username: 'admin'
+smtp_password: 'password'

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -7,12 +7,16 @@ local_vagrant ansible_host=127.0.0.1 ansible_user=vagrant ansible_port=2222 ansi
 [lxc]
 ofn.local
 
+[lexi]
+local_lexi ansible_host=10.10.100.10 ansible_ssh_common_args='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR'
+
 [travis]
 local_travis
 
 [local:children]
 vagrant
 lxc
+lexi
 travis
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Adds configs for using `lexi` for testing ofn-install. Uses Linux Containers via LXD.

See: https://github.com/libre-ops/lexi for installation and usage (it's really good...)