### PR TITLE
Enable French and English in Katuma

### DIFF
--- a/inventory/group_vars/es.yml
+++ b/inventory/group_vars/es.yml
@@ -4,7 +4,7 @@ checkout_zone: Europe
 country_code: ES
 currency: EUR
 locale: es
-available_locales: es,ca,pt,it
+available_locales: es,ca,pt,it,fr,en
 language: es_ES.UTF-8
 language_packages:
   - language-pack-es-base


### PR DESCRIPTION
A new hub that trades with French customers asked Katuma for these languages.