### PR TITLE
Enable apm for UK and AU

### DIFF
--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -22,3 +22,5 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: metabase, address: '167.99.89.242/32', auth_method: md5 }
+
+disable_datadog: true

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -31,3 +31,5 @@ custom_hba_entries:
 
 custom_application_env_vars: |
   OFN_FEATURE_CONNECT_AND_LEARN: "true"
+
+enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug

--- a/inventory/host_vars/staging.katuma.org/config.yml
+++ b/inventory/host_vars/staging.katuma.org/config.yml
@@ -5,5 +5,3 @@ rails_env: staging
 admin_email: info@coopdevs.org
 
 mail_domain: katuma.org
-
-disable_datadog: true

--- a/inventory/host_vars/staging.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/staging.openfoodfrance.org/config.yml
@@ -9,5 +9,3 @@ admin_email: admin@openfoodfrance.org
 mail_domain: openfoodfrance.org
 
 unicorn_timeout: 120
-
-disable_datadog: true

--- a/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
@@ -7,5 +7,3 @@ rails_env: staging
 admin_email: dev.ofnuk@gmail.com
 
 unicorn_timeout: 120
-
-disable_datadog: true

--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -20,3 +20,4 @@ custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 enable_nginx_logging: true
+enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug


### PR DESCRIPTION
Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/5085

Since UK was the first instance to enable this service, and disable it later on, its settings are still in `ofn-secrets` but AU needs openfoodfoundation/ofn-secrets#29.

I removed old disabling commands from staging servers, that I can confirm, don't have the DD agent running. I manually expired their API keys to be extra sure. 

I also disabled it for Katuma production since we don't check its monitoring and AU needs it much more than Katuma.