### PR TITLE
Do not become_user: postgres when including role

### DIFF
--- a/playbooks/db_integrations.yml
+++ b/playbooks/db_integrations.yml
@@ -34,8 +34,6 @@
       when: db_integrations is defined
 
     - name: Reconfigure postgres
-      become: yes
-      become_user: postgres
       include_role:
         name: geerlingguy.postgresql
         tasks_from: configure


### PR DESCRIPTION
This fixes the error:

```
ERROR! 'become_user' is not a valid attribute for a IncludeRole
The error appears to be in '/home/pau/dev/ofn-install/playbooks/db_integrations.yml': line 36, column 7, but may
be elsewhere in the file depending on the exact syntax problem.
```

This is consistent with the `include_role` calls we have in `roles/db_server/` and works I managed to run this playbook against AU production.