### PR TITLE
Enable use of separate API key for javascript Bugsnag calls

### DIFF
--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -51,5 +51,8 @@ STRIPE_ENDPOINT_SECRET: {{ stripe_endpoint_secret }}
 {% if bugsnag_key is defined %}
 BUGSNAG_API_KEY: {{ bugsnag_key }}
 {% endif %}
+{% if bugsnag_js_key is defined %}
+BUGSNAG_JS_KEY: {{ bugsnag_js_key }}
+{% endif %}
 
 {{ custom_application_env_vars | default('') }}


### PR DESCRIPTION
Twinned with: https://github.com/openfoodfoundation/openfoodnetwork/pull/5113

Allows configuration of a separate Bugsnag API key for javascript errors per-instance.