### PR TITLE
Make ofn-install run on Ansible 2.9.6

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+ofn-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,7 @@ before_install:
     fi
 
 install:
-  - pip install 'ansible==2.9.6'
-  - pip install 'ansible-lint==4.1.0'
+  - pip install -r requirements.txt
 
 script:
   - bin/setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
     fi
 
 install:
-  - pip install 'ansible==2.7.10'
+  - pip install 'ansible==2.9.6'
   - pip install 'ansible-lint==4.1.0'
 
 script:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Start with our [deployment tutorial](https://github.com/openfoodfoundation/ofn-i
 
 ## Playbooks
 
+These playbooks will install the Open Food Network app onto a server running an apt-compatible OS like Debian or Ubuntu. It has currently been tested on **Ubuntu 16.04 (64 bit) LTS** on AWS, DigitalOcean and Scaleway cloud servers.
+
 The playbooks take information from the inventory. Make sure that your host's information is up to date before running a playbook. Make also sure to include your host's secrets file.
 
 These are the main playbooks:
@@ -25,18 +27,33 @@ You may want to use the [anisble option "checkrun"](http://docs.ansible.com/play
 
 ## Requirements
 
-You will need Ansible on your machine to run the playbooks.
-These playbooks will install the Open Food Network app onto a server running an apt-compatible OS like Debian or Ubuntu. It has currently been tested on **Ubuntu 16.04 (64 bit) LTS** on AWS, DigitalOcean and Scaleway cloud servers.
+You will need to install Ansible, alongside other dependencies, on your machine to run the playbooks. You can do so with:
 
+```
+pip install -r requirements.txt
+```
+
+Before that, it's recommended you set up your Python environment using [Pyenv](https://github.com/pyenv/pyenv).
+
+In that case, you need to:
+
+* Install and configure [pyenv](https://github.com/pyenv/pyenv)
+* Install and configure [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)
+* Install the required Python version:
+
+```
+$ pyenv install 3.8.2
+```
+
+* Create the virtualenv:
+
+```
+$ pyenv virtualenv 3.8.2 ofn-install
+```
 
 ## Code quality
 
-Install [ansible-lint](https://github.com/willthames/ansible-lint) by running:
-```
-pip install ansible-lint
-```
-
-Run the checks using:
+Run the [ansible-lint](https://github.com/willthames/ansible-lint) checks using:
 ```
 ansible-lint site.yml --exclude=community
 ```

--- a/playbooks/db_integrations.yml
+++ b/playbooks/db_integrations.yml
@@ -34,8 +34,6 @@
       when: db_integrations is defined
 
     - name: Reconfigure postgres
-      become: yes
-      become_user: postgres
       include_role:
         name: geerlingguy.postgresql
         tasks_from: configure

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ansible==2.9.6
+ansible-lint==4.2.0
+yamllint==1.21.0


### PR DESCRIPTION
This brings in the [requirements file](https://pip.readthedocs.io/en/1.1/requirements.html) Python uses to manage dependencies with Pip, Python's package manager, to migrate to Ansible 2.9.6.

Then, as we do with `bundle install`, when dependencies are changed, you need to run `pip install -r requirements.txt`.

It makes use of [Pyenv](https://github.com/pyenv/pyenv) (an Rbenv's clone to manage Python versions) and its [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) plugin.
This relies on a [virtualenv](https://virtualenv.pypa.io/en/latest/) set up in your environment called `ofn-install`. It's the same idea as RVM's gemsets and it's the way Python isolates dependencies.

This is what we've been using in all our Python projects at Coopdevs (which is almost all of them).