### PR TITLE
Fix nginx config for lexi

### DIFF
--- a/inventory/group_vars/lexi.yml
+++ b/inventory/group_vars/lexi.yml
@@ -15,3 +15,51 @@ developer_email: admin@example.com
 
 users_sysadmin:
   - "{{ core_devs }}"
+
+# Override default nginx settings because we don't have TLS
+nginx_sites:
+  default:
+    - |
+      listen 80 default_server;
+      listen [::]:80 default_server;
+      server_name  _;
+      add_header X-Content-Type-Options nosniff always;
+      add_header X-Xss-Protection "1; mode=block" always;
+      add_header X-Frame-Options DENY always;
+      add_header Content-Security-Policy "default-src none" always;
+
+  ofn_80:
+    - |
+      listen 80;
+      listen [::]:80;
+      server_name {{ domain }};
+      root {{ app_root }}/public;
+
+      add_header X-Content-Type-Options nosniff always;
+      add_header X-Xss-Protection "1; mode=block" always;
+
+      gzip on;
+      gzip_disable "msie6";
+
+      try_files $uri/index.html $uri @unicorn;
+      location @unicorn {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+        proxy_pass http://unicorn;
+      }
+
+      location ~ ^/(assets)/ {
+        gzip_static on;
+        expires max;
+        add_header Cache-Control public;
+        #add_header Last-Modified "";
+        #add_header ETag "";
+      }
+
+      error_page 500 502 503 504 /500.html;
+      client_max_body_size 4G;
+      keepalive_timeout 60;
+
+      include /etc/nginx/sites-available/ofn/*;


### PR DESCRIPTION
I must have missed this when committing previously. 

Tweaks the nginx configs for lexi (LXD) containers so they work without letsencrypt certificates.