### PR TITLE
Kill Unicorns

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -141,7 +141,19 @@ logrotate_applications:
           - "{{ current_path }}/log/*.log"
         options:
           - weekly        # rotate weekly
-          - rotate 4     # delete logs older than 4 rotations
+          - rotate 4      # delete logs older than 4 rotations
+          - compress      # compress rotated logs
+          - missingok     # ignore missing logs
+          - notifempty    # don't rotate if empty
+          - copytruncate  # copy the log, then empty the active logfile
+
+  - name: unicorn
+    definitions:
+      - logs:
+          - "{{ shared_path }}/log/unicorn.log"
+        options:
+          - weekly        # rotate weekly
+          - rotate 4      # delete logs older than 4 rotations
           - compress      # compress rotated logs
           - missingok     # ignore missing logs
           - notifempty    # don't rotate if empty

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -180,6 +180,8 @@ unicorn_pid: "{{ pid_path }}/unicorn.pid"
 unicorn_sock: "{{ sock_path }}/unicorn.{{ app }}.sock"
 unicorn_workers: 2
 unicorn_timeout: 30
+unicorn_env_vars: |
+  KILL_UNICORNS=true
 
 #----------------------------------------------------------------------
 # Memcached variables

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -33,3 +33,8 @@ custom_application_env_vars: |
   OFN_FEATURE_CONNECT_AND_LEARN: "true"
 
 enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug
+
+unicorn_env_vars: |
+  KILL_UNICORNS=true
+  UWK_MEM_MIN=1900
+  UWK_MEM_MAX=2100

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -11,6 +11,7 @@
   with_items:
     - { src: "unicorn_init.j2", dest: "/etc/init.d/unicorn_{{ app }}" }
     - { src: "unicorn.service.j2", dest: "/etc/systemd/system/unicorn_{{ app }}.service" }
+    - { src: "unicorn_environment.j2", dest: "{{ shared_path }}/unicorn_environment" }
     - { src: "delayed_job.service.j2", dest: "/etc/systemd/system/delayed_job_{{ app }}.service" }
   register: init_scripts
   notify:

--- a/roles/webserver/templates/unicorn.service.j2
+++ b/roles/webserver/templates/unicorn.service.j2
@@ -7,7 +7,7 @@ Description=Open Food Network unicorn server
 Type=forking
 User=openfoodnetwork
 WorkingDirectory={{ current_path }}
-Environment=RAILS_ENV={{ rails_env }}
+EnvironmentFile={{ shared_path }}/unicorn_environment
 
 {% if skylight_authentication is defined %}
   Environment=SKYLIGHT_AUTHENTICATION={{ skylight_authentication }}

--- a/roles/webserver/templates/unicorn_environment.j2
+++ b/roles/webserver/templates/unicorn_environment.j2
@@ -1,0 +1,2 @@
+RAILS_ENV={{ rails_env }}
+{{ unicorn_env_vars | default('') }}


### PR DESCRIPTION
- Enables `unicorn-worker-killer` on all staging and production servers.
- Adds a missing lograte entry for exponential unicorn log
- Improves how ENV vars passed to unicorn service