### PR TITLE
Increase Postgres work_mem

### DIFF
--- a/playbooks/postgres_tuning.yml
+++ b/playbooks/postgres_tuning.yml
@@ -16,7 +16,7 @@
           effective_cache_size = {{ ( ( ansible_memtotal_mb / 4 ) * 3 ) | int }}MB
           maintenance_work_mem = {{ ( ansible_memtotal_mb / 16 ) | int }}MB
           wal_buffers = 16MB
-          work_mem = 6MB
+          work_mem = 64MB
         dest: "{{ postgresql_config_path }}/conf.d/tuning.conf"
       become: yes
       become_user: postgres


### PR DESCRIPTION
This tunes a few memory-related Postgres settings that we hope will make use of the available RAM. Still, the server is not leveraging those 16Gb RAM.

I based my decision on https://www.citusdata.com/blog/2018/06/12/configuring-work-mem-on-postgres/. It's not the first time I read `work_mem` should be much higher than the default. I remember reading time ago that it should be 16Mb. We need to check and see :man_shrugging: 

This has already been applied to the UK.