### PR TITLE
Reload unicorn on deploy instead of restart

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -71,7 +71,7 @@
   tags:
     - bundle_app
     - skip_ansible_lint
-  notify: restart unicorn
+  notify: reload unicorn
 
 # Update the database
 
@@ -98,7 +98,7 @@
   tags:
     - rake
     - skip_ansible_lint
-  notify: restart unicorn
+  notify: reload unicorn
 
 - name: seed database
   command: bash -lc "bundle exec rake db:seed RAILS_ENV={{ rails_env }}"
@@ -107,7 +107,7 @@
   tags:
     - seed
     - skip_ansible_lint
-  notify: restart unicorn
+  notify: reload unicorn
 
 # Precompile assets
 

--- a/roles/shared_handlers/handlers/main.yml
+++ b/roles/shared_handlers/handlers/main.yml
@@ -1,5 +1,22 @@
 # This role holds reusable handlers that can be included in multiple playbooks to keep things DRY
 
+- name: ensure unicorn is started
+  service:
+    name: unicorn_{{ app }}
+    state: started
+  become: yes
+  become_user: root
+  listen: reload unicorn
+  register: unicorn_started
+
+- name: reload unicorn
+  service:
+    name: unicorn_{{ app }}
+    state: reloaded
+  become: yes
+  become_user: root
+  when: not unicorn_started.changed
+
 - name: restart unicorn
   service:
     name: unicorn_{{ app }}

--- a/roles/webserver/handlers/main.yml
+++ b/roles/webserver/handlers/main.yml
@@ -1,8 +1,8 @@
 - name: check service status
   service_facts:
-  listen: reload unicorn
+  listen: reload unicorn configs
 
-- name: reload unicorn
+- name: reload unicorn configs
   service:
     name: unicorn_{{ app }}
     state: reloaded

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -27,7 +27,7 @@
     group: "{{ unicorn_user }}"
   become: yes
   tags: unicorn_config
-  notify: reload unicorn
+  notify: reload unicorn configs
 
 - name: Reload systemd
   systemd:


### PR DESCRIPTION
This change means that if a unicorn worker is part-way through serving a request at the point of deployment, it will be restarted as soon as it's finished instead of killing the request.

Also adds a quick check for cases where unicorn is not running yet (on first deploy for example) which would otherwise throw an error (you can't reload a service that hasn't been started yet).

### What should we test?

The Travis build does two deployments, but we should do a quick deploy to staging as well.