### PR TITLE
Ansible tuning

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 roles_path = ./community:./roles
 inventory = ./inventory/hosts
+forks = 10
 
 callback_whitelist = profile_tasks
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,4 +7,5 @@ callback_whitelist = profile_tasks
 
 # Needed to resolve a problem with task output
 [ssh_connection]
+pipelining = True
 control_path = %(directory)s/%%h-%%r

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -11,13 +11,11 @@
 
   tasks:
     - name: Check we're not deploying master to production
-      pause:
-        prompt: |
-          WARNING: The current settings will deploy `master` branch to a production server!
-          Check for typos in the command if deploying a release, otherwise type YES to proceed
+      fail:
+        msg: |
+          WARNING: The current settings would deploy `master` branch to a production server!
+          Check for typos in the command if deploying a release.
       when: inventory_hostname in groups['all-prod'] and git_version == "master"
-      register: deployment_check
-      failed_when: deployment_check.user_input != "YES"
 
     - block:
       - include_role:

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -1,6 +1,7 @@
 ---
 - name: deploy
   hosts: ofn_servers
+  strategy: free
   remote_user: "{{ user }}"
   become: yes
   become_user: "{{ unicorn_user }}"

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -15,6 +15,7 @@
 
 - name: provision
   hosts: ofn_servers
+  strategy: free
   remote_user: "{{ user }}"
 
   pre_tasks:


### PR DESCRIPTION
Closes #588 
Related to: #575 

Adds some enhancements to Ansible itself and to some playbooks:

**Enable Ansible's "Pipelining" feature**

Reduces the number of active connections and the amount of data transferred by Ansible when it runs tasks. This should reduce latency issues during trans-atlantic playbook execution

**Increase Ansible forking maximum**

Maximum number of forking processes Ansible will create locally when running playbooks against multiple servers. The default is 5. We regularly run playbooks on 8 servers at once (all-prod), so this should help speed things up.

**Use "free" strategy in provision and deploy playbooks**

When running playbooks on multiple servers, Ansible will normally wait until every server has completed a task before moving to the next one. Using the "free" strategy in a playbook disables this behaviour; tasks will proceed on each server as quickly as they can.

