### PR TITLE
Check unicorn client connections

### DIFF
--- a/roles/webserver/templates/unicorn.rb.j2
+++ b/roles/webserver/templates/unicorn.rb.j2
@@ -7,6 +7,12 @@ listen "{{ unicorn_sock }}"
 worker_processes {{ unicorn_workers }}
 timeout {{ unicorn_timeout }}
 
+# Enable this flag to have unicorn test client connections by writing the
+# beginning of the HTTP headers before calling the application. This
+# prevents calling the application for connections that have disconnected
+# while queued.
+check_client_connection true
+
 # The following enables use of the Ruby 2.0+ Copy-On-Write feature
 # for more efficient memory usage in Unicorn workers.
 


### PR DESCRIPTION
This setting means unicorn doesn't get hit if the queued connection has been cancelled before it gets to unicorn, i.e. if a user hits the refresh button 10 times in 1 second, don't process each of those requests because most of them are already technically been terminated on the client side.

Details in the original commit notes: https://github.com/defunkt/unicorn/commit/5c700fc2cf398848ddcf71a2aa3f0f2a6563e87b

The notes mention it worked really well on Black Friday, so this should help with our "Black Monday" situations on UK Prod :trollface: 