### PR TITLE
Tell Datadog which app version was deployed

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -38,7 +38,7 @@
           method: POST
           body:
             title: "Deployed"
-            text: "Successful deployment on host: {{ inventory_hostname }} ({{ host_id | default(ansible_limit) }})"
+            text: "Successful deployment of {{ git_version }} on host: {{ inventory_hostname }} ({{ host_id | default(ansible_limit) }})"
             host: "{{ inventory_hostname }}"
             tags:
               - "deployed"


### PR DESCRIPTION
I wanted to correlate the changes in performance with a particular release but we are missing that data in Datadog.