### PR TITLE
Upgrade CI to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 ---
 sudo: required
-dist: bionic
+dist: xenial
 cache: bundler
 language: python
-python: 3.8
+python: 3.7.1
 services:
   - postgresql
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 ---
 sudo: required
-dist: xenial
+dist: bionic
 cache: bundler
 language: python
-python: "2.7"
+python: 3.8
 services:
   - postgresql
 addons:


### PR DESCRIPTION
We better run our CI on a Python supported version. Not sure which sort of edge cases we might run into with the latest Ansible but an unmaintained Python version.

~This also requires upgrading to Ubuntu 18.04 but AU has been running it in production for quite some time so we do know it's safe.~