### PR TITLE
Forcefully restart PostgreSQL to reload config

### DIFF
--- a/playbooks/postgres_tuning.yml
+++ b/playbooks/postgres_tuning.yml
@@ -20,7 +20,7 @@
         dest: "{{ postgresql_config_path }}/conf.d/tuning.conf"
       become: yes
       become_user: postgres
-      notify: reload postgres
+      notify: restart postgres
       when: remove_postgres_tuning is undefined
 
     - name: Optionally remove tuning configuration
@@ -30,8 +30,8 @@
       when: remove_postgres_tuning is defined
 
   handlers:
-    - name: reload postgres
+    - name: restart postgres
       service:
         name: postgresql
-        state: reloaded
+        state: restarted
       become: yes


### PR DESCRIPTION
I noticed today that the changes we did to UK's settings for PostgreSQL to take up more RAM weren't loaded by the server. A query against the `pg_settings` view returned (among other settings):

```
name            | shared_buffers
setting         | 16384 # Equivalent to 128MB
unit            | 8kB
category        | Resource Usage / Memory
short_desc      | Sets the number of shared memory buffers used by the server.
extra_desc      |
context         | postmaster
vartype         | integer
source          | configuration file
min_val         | 16
max_val         | 1073741823
enumvals        |
boot_val        | 1024
reset_val       | 16384
sourcefile      |
sourceline      |
pending_restart | t
```

So yes, manually restarting the server switched that `pending_restart` to false and the setting's value is now 4011MB, which is what we wanted.

It turns out a `systemd reload` has nothing to do with a PostgreSQL `pg_reload_conf()`. Restart it's just fine for us and gets the job done.