### PR TITLE
Add zapier configs to ca-prod

### DIFF
--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -13,3 +13,9 @@ unicorn_timeout: 120
 certbot_domains:
   - openfoodnetwork.ca
   - www.openfoodnetwork.ca
+
+postgres_listen_addresses:
+  - '*'
+
+custom_hba_entries:
+  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }


### PR DESCRIPTION
Part of #605 

Adds Zapier configs for `ca-prod`.

After the secrets changes in https://github.com/openfoodfoundation/ofn-secrets/pull/35 are merged, and the changes here are merged, we need to:
- run the `db_integrations.yml` playbook on `ca-prod`
- provision `ca-prod`