### PR TITLE
Add config settings for Katuma's server migration

### DIFF
--- a/inventory/host_vars/migration.katuma.org/config.yml
+++ b/inventory/host_vars/migration.katuma.org/config.yml
@@ -1,0 +1,21 @@
+---
+domain: app.katuma.org
+host_id: es-prod
+rails_env: production
+
+admin_email: info@coopdevs.org
+
+mail_domain: katuma.org
+
+certbot_domains:
+  - app.katuma.org
+  - alpha.katuma.org
+  - migration.katuma.org
+
+certbot_cert_name: app.katuma.org
+
+postgres_listen_addresses:
+  - '*'
+
+custom_hba_entries:
+  - { type: hostssl, database: "{{ db }}", user: metabase, address: '167.99.89.242/32', auth_method: md5 }

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -97,9 +97,13 @@ app.katuma.org ansible_host=51.15.136.157
 [es-staging]
 staging.katuma.org ansible_host=51.15.216.10
 
+[es-migration]
+migration.katuma.org ansible_host=116.203.60.113
+
 [es:children]
 es-prod
 es-staging
+es-migration
 
 #------------------------------------------------------------------------------
 # France


### PR DESCRIPTION
Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/5418

I dropped the following from the existing config:

* `swapfile_size`: We migrate to have more RAM (8GB) thus, no need for swap
anymore
* `enable_nginx_logging`: Datadog is not enabled so this config is set
but not used.
* `disable_datadog`: The new server doesn't have it so a `true` won't
take in effect here.

I added the extra `certbot_domains` entry as documented in
https://github.com/openfoodfoundation/ofn-install/wiki/Migrating-a-Production-Server.

As for the entry `alpha.katuma.org`, the old subdomain we redirect to `app.katuma.org`, we need to decide whether we still maintain it or not. It's likely that we'll take the chance to drop it.