### PR TITLE
Rsync asset transfer

### DIFF
--- a/playbooks/transfer_assets.yml
+++ b/playbooks/transfer_assets.yml
@@ -7,6 +7,12 @@
   hosts: ofn_servers
   remote_user: "{{ user }}"
 
+  pre_tasks:
+    - name: ensure rsync target is valid and singular
+      fail:
+        msg: "Rsync target must be a single valid host, e.g. `-e 'rsync_to=uk-staging'`"
+      when: (groups[rsync_to] | length) != 1
+
   tasks:
     - include_role:
         name: migrate_assets

--- a/playbooks/transfer_assets.yml
+++ b/playbooks/transfer_assets.yml
@@ -1,5 +1,8 @@
 ---
 
+# Transfers all custom assets directly from one server to another using Rsync and SSH forwarding.
+# Requires "rsync_to" variable as remote server for rsync e.g: `-e "rsync_to=uk-staging"`.
+
 - name: Transfer assets
   hosts: ofn_servers
   remote_user: "{{ user }}"

--- a/playbooks/transfer_assets.yml
+++ b/playbooks/transfer_assets.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Transfer assets
+  hosts: ofn_servers
+  remote_user: "{{ user }}"
+
+  tasks:
+    - include_role:
+        name: migrate_assets
+        tasks_from: rsync_assets.yml

--- a/roles/db_transfer/tasks/main.yml
+++ b/roles/db_transfer/tasks/main.yml
@@ -28,7 +28,7 @@
     src: "{{ admin_dump_path }}"  # Source on target host specified in --limit
     dest: "{{ admin_dump_path }}" # Dest on host specified in {{ rsync_to }}
   vars:
-    ansible_ssh_extra_args: '-o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout 600'
+    ansible_ssh_extra_args: '-o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=600'
   delegate_to: "{{ groups[rsync_to][0] }}"
 
 - name: move to postgres-owned path # noqa 301

--- a/roles/migrate_assets/defaults/main.yml
+++ b/roles/migrate_assets/defaults/main.yml
@@ -6,5 +6,6 @@ local_asset_path: "../backups"
 
 migrate_dirs:
   - assets
+  - images
   - spree
   - system

--- a/roles/migrate_assets/tasks/rsync_assets.yml
+++ b/roles/migrate_assets/tasks/rsync_assets.yml
@@ -12,6 +12,7 @@
     ansible_ssh_extra_args: "-l {{ unicorn_user }} -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=600"
   loop:
     - assets
+    - images
     - spree
     - system
   loop_control:

--- a/roles/migrate_assets/tasks/rsync_assets.yml
+++ b/roles/migrate_assets/tasks/rsync_assets.yml
@@ -3,12 +3,13 @@
 - name: rsync asset files with ssh forwarding
   synchronize:
     src: "{{ shared_path }}/{{ migrate_dir }}"  # Source on target host specified in --limit
-    dest: "{{ shared_path }}/{{ migrate_dir }}" # Dest on host specified in {{ rsync_to }}
+    dest: "{{ shared_path }}/"                  # Dest on host specified in {{ rsync_to }}
     mode: pull
+    set_remote_user: false
     rsync_opts:
       - "--chown={{ unicorn_user }}:{{ unicorn_user }}"
   vars:
-    ansible_ssh_extra_args: '-o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout 600'
+    ansible_ssh_extra_args: "-l {{ unicorn_user }} -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=600"
   loop:
     - assets
     - spree

--- a/roles/migrate_assets/tasks/rsync_assets.yml
+++ b/roles/migrate_assets/tasks/rsync_assets.yml
@@ -9,7 +9,9 @@
     rsync_opts:
       - "--chown={{ unicorn_user }}:{{ unicorn_user }}"
   vars:
-    ansible_ssh_extra_args: "-l {{ unicorn_user }} -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=600"
+    ansible_ssh_extra_args: >
+      -l {{ unicorn_user }} -o ForwardAgent=yes -o UserKnownHostsFile=/dev/null
+      -o StrictHostKeyChecking=no -o ConnectTimeout=600
   loop: "{{ migrate_dirs }}"
   loop_control:
     loop_var: migrate_dir

--- a/roles/migrate_assets/tasks/rsync_assets.yml
+++ b/roles/migrate_assets/tasks/rsync_assets.yml
@@ -10,11 +10,7 @@
       - "--chown={{ unicorn_user }}:{{ unicorn_user }}"
   vars:
     ansible_ssh_extra_args: "-l {{ unicorn_user }} -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=600"
-  loop:
-    - assets
-    - images
-    - spree
-    - system
+  loop: "{{ migrate_dirs }}"
   loop_control:
     loop_var: migrate_dir
   delegate_to: "{{ groups[rsync_to][0] }}"

--- a/roles/migrate_assets/tasks/rsync_assets.yml
+++ b/roles/migrate_assets/tasks/rsync_assets.yml
@@ -1,0 +1,18 @@
+---
+
+- name: rsync asset files with ssh forwarding
+  synchronize:
+    src: "{{ shared_path }}/{{ migrate_dir }}"  # Source on target host specified in --limit
+    dest: "{{ shared_path }}/{{ migrate_dir }}" # Dest on host specified in {{ rsync_to }}
+    mode: pull
+    rsync_opts:
+      - "--chown={{ unicorn_user }}:{{ unicorn_user }}"
+  vars:
+    ansible_ssh_extra_args: '-o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout 600'
+  loop:
+    - assets
+    - spree
+    - system
+  loop_control:
+    loop_var: migrate_dir
+  delegate_to: "{{ groups[rsync_to][0] }}"


### PR DESCRIPTION
Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/5418

Adds a playbook for transferring all custom instance assets directly between two servers using rsync and SSH forwarding.

Uses the same transfer method as the (relatively new) `db_transfer` playbook.

Katuma uses local storage for images, and we have to transfer ~1.3GB of assets between the two servers for the migration. So: lets do it in one fast transfer of 1.3GB using the high bandwidth of two web servers, instead of two slow transfers of 1.3GB download and then 1.3GB upload (with crappy bandwidth both ways)... 

:rocket: