### PR TITLE
Add "install yarn" to the provision playbook and "yarn install" to the deploy playbook

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -5,6 +5,9 @@
 - src: zzet.rbenv
   version: 3.4.2
 
+- src: geerlingguy.nodejs
+  version: 5.1.1
+
 - src: jdauphant.nginx
   version: v2.8.1
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -23,7 +23,6 @@ git_version: "{{ github_key.split(':')[1] }}"
 
 l10n_git_version: HEAD
 
-
 #----------------------------------------------------------------------
 # Default values (should be overridden in each server config)
 rails_env: staging
@@ -103,6 +102,13 @@ postgresql_global_config_options:
     value: "conf.d"
 
 debezium_version: "0.10.0.Final"
+
+#----------------------------------------------------------------------
+# Yarn/node variables
+npm_prefix: "/usr/local/lib/npm"
+
+node_version: 14.x
+yarn_version: 1.22.4
 
 #----------------------------------------------------------------------
 # App variables

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -67,6 +67,10 @@
       become_user: "{{ unicorn_user }}"
       tags: app
 
+    - role: yarn
+      become: yes
+      tags: yarn
+
     - role: dbserver # Set up database server and user for the app.
       become: yes
       become_user: root

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -77,7 +77,7 @@
 
 - name: run yarn install
   yarn:
-    path: "{{ current_path }}"
+    path: "{{ build_path }}"
     executable: "{{ npm_prefix }}/bin/yarn"
     production: yes
   become: true

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -78,7 +78,7 @@
 - name: run yarn install
   yarn:
     path: "{{ current_path }}"
-    executable: "/usr/local/lib/npm/bin/yarn"
+    executable: "{{ npm_prefix }}/bin/yarn"
     production: yes
   become: true
   become_user: "{{ unicorn_user }}"

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -73,6 +73,16 @@
     - skip_ansible_lint
   notify: restart unicorn
 
+# Install JS dependencies with yarn
+
+- name: run yarn install
+  yarn:
+    path: "{{ current_path }}"
+    executable: "/usr/local/lib/npm/bin/yarn"
+    production: yes
+  become: true
+  become_user: "{{ unicorn_user }}"
+
 # Update the database
 
 - name: check database status

--- a/roles/yarn/defaults/main.yml
+++ b/roles/yarn/defaults/main.yml
@@ -1,0 +1,4 @@
+npm_prefix: "/usr/local/lib/npm"
+
+node_version: 14.x
+yarn_version: 1.22.4

--- a/roles/yarn/defaults/main.yml
+++ b/roles/yarn/defaults/main.yml
@@ -1,4 +1,0 @@
-npm_prefix: "/usr/local/lib/npm"
-
-node_version: 14.x
-yarn_version: 1.22.4

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: install node.js
+  include_role:
+    name: geerlingguy.nodejs
+  vars:
+    nodejs_version: "{{ node_version }}"
+    npm_config_prefix: "{{ npm_prefix }}"
+
+- name: install yarn
+  npm:
+    name: yarn
+    version: "{{ yarn_version }}"
+    global: true
+    state: present
+  environment:
+    NPM_CONFIG_PREFIX: "{{ npm_prefix }}"
+    NODE_PATH: "{{ npm_prefix }}/lib/node_modules"


### PR DESCRIPTION
This installs node and npm using https://github.com/geerlingguy/ansible-role-nodejs
and then uses npm to install yarn.

I tried a few other things but this was the only way to control the exact version of yarn we install. I didnt manage to control exact version of node though. So, with this we have node 14.x and yarn 1.22.4

node --version
v14.2.0
yarn --version
1.22.4


How to test:
- provisioning a server should leave node and yarn available on the command line
- deploy a version should create the node_modules folder - this folder will be empty for now because production mode will not deploy devDependencies. I tested this without the production flag and the modules like karma were deployed :+1:
