### PR TITLE
Use user with the necessary permissions

### DIFF
--- a/playbooks/transfer_assets.yml
+++ b/playbooks/transfer_assets.yml
@@ -5,7 +5,7 @@
 
 - name: Transfer assets
   hosts: ofn_servers
-  remote_user: "{{ user }}"
+  remote_user: "{{ unicorn_user }}"
 
   pre_tasks:
     - name: ensure rsync target is valid and singular


### PR DESCRIPTION
This fixes the following failure we had at the first attempt at migrating the assets

```
failed: [app.katuma.org -> 116.203.60.113] (item=images) => {                                                                                                                         [141/1202]
    "ansible_loop_var": "migrate_dir",                                                                                                                                                          
    "changed": false,                                                                                                                                                                           
    "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh=/usr/bin/ssh -S none -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null --chown=openfoodnetwork:openfoodnetwor
k --out-format=<<CHANGED>>%i %n%L 51.15.136.157:/home/openfoodnetwork/apps/openfoodnetwork/shared/images /home/openfoodnetwork/apps/openfoodnetwork/shared/",                                   
    "invocation": {                                                                                                                                                                             
        "module_args": {                                                                                                                                                                        
            "_local_rsync_password": null,                                                                                                                                                      
            "_local_rsync_path": "rsync", 
            "_substitute_controller": false, 
            "archive": true, 
            "checksum": false, 
            "compress": true, 
            "copy_links": false, 
            "delete": false, 
            "dest": "/home/openfoodnetwork/apps/openfoodnetwork/shared/", 
            "dest_port": null, 
            "dirs": false, 
            "existing_only": false, 
            "group": null, 
            "link_dest": null, 
            "links": null, 
            "mode": "pull", 
            "owner": null, 
            "partial": false, 
            "perms": null, 
            "private_key": null, 
            "recursive": null, 
            "rsync_opts": [
                "--chown=openfoodnetwork:openfoodnetwork"
            ], 
            "rsync_path": null, 
            "rsync_timeout": 0, 
            "set_remote_user": false, 
            "src": "51.15.136.157:/home/openfoodnetwork/apps/openfoodnetwork/shared/images", 
            "ssh_args": null, 
            "times": null, 
            "verify_host": false
        }
    }, 
    "migrate_dir": "images", 
    "msg": "Warning: Permanently added '51.15.136.157' (ECDSA) to the list of known hosts.\r\nrsync: failed to set times on \"/home/openfoodnetwork/apps/openfoodnetwork/shared/images\": Operat
ion not permitted (1)\nrsync: recv_generator: mkdir \"/home/openfoodnetwork/apps/openfoodnetwork/shared/images/enterprise_groups\" failed: Permission denied (13)\n*** Skipping any contents fro
m this failed directory ***\nrsync: recv_generator: mkdir \"/home/openfoodnetwork/apps/openfoodnetwork/shared/images/enterprises\" failed: Permission denied (13)\n*** Skipping any contents fro
m this failed directory ***\nrsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1668) [generator=3.1.2]\n", 
    "rc": 23
}
```

This is because the app is in the unicorn user's home directory and it's not letting the ofn-admin user make directories there. The ofn-admin user does not belong to the app user's group.