### PR TITLE
Install lib required by wkhtmltopdf

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -41,6 +41,7 @@
       - libxml2-dev
       - libxslt1-dev
       - memcached
+      - libxrender1
   tags: packages
 
 - name: add memcached configuration


### PR DESCRIPTION
Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/5418

Without it, in the brand new Katuma's server we suddenly got this error when printing invoices:

```
2020-05-20T16:35:17+0200: [Worker(delayed_job host:katuma-production pid:17737)] Job BulkInvoiceService#start_pdf_job_without_delay (id=695942) FAILED (3 prior attempts) with RuntimeError: Failed to execute:
["/home/openfoodnetwork/.gem/ruby/2.3.0/bin/wkhtmltopdf", "-q", "--encoding", "UTF-8", "file:////tmp/wicked_pdf20200520-17737-vogzkt.html", "/tmp/wicked_pdf_generated_file20200520-17737-e9yk2z.pdf"]
Error: PDF could not be generated!
 Command Error: /home/openfoodnetwork/.gem/ruby/2.3.0/gems/wkhtmltopdf-binary-0.12.5/bin/wkhtmltopdf_ubuntu_18.04_amd64: error while loading shared libraries: libXrender.so.1: cannot open shared object file: No such file or directory
```

I haven't found a clear explanation because last upgrade of the wkhtmltopdf-binary-gem was done in November 2019 in https://github.com/openfoodfoundation/openfoodnetwork/commit/1b8863b63dfb36ad906645a0746cf7e504a4dbb5 and the changelog listed there doesn't report anything about `libXrender`.

Another possibility could be that Katuma and AU are using two different patch versions of Ubuntu 18.04.