### PR TITLE
Fix outdated nginx package issue

### DIFF
--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -28,3 +28,11 @@
     - role: ssh_keys
       become: yes
       tags: ssh_keys
+
+  tasks:
+    - name: purge outdated nginx packages
+      apt:
+        name: nginx
+        state: absent
+        purge: yes
+      become: yes


### PR DESCRIPTION
Purges any potential outdated `nginx` packages that come pre-installed in the server (during setup).

Outdated nginx packages can sometimes cause issues and refuse to be updated. This bug is difficult to reproduce and seems to vary depending on the image used. Only affects new server installs, but we've encountered this several times and purging `nginx` before provisioning fixes it.

#### Testing

Green build should be enough. If the task succeeds in the CI build, there's nothing more to check.