### PR TITLE
Restart PostgreSQL when user is added

### DIFF
--- a/roles/db_integrations/tasks/main.yml
+++ b/roles/db_integrations/tasks/main.yml
@@ -11,6 +11,7 @@
     db: "{{ db }}"
     role_attr_flags: LOGIN,INHERIT,NOSUPERUSER,NOCREATEDB,NOCREATEROLE,NOREPLICATION
     state: present
+  notify: restart postgresql
   when: db_integration.state == 'present'
   register: integration_config
 


### PR DESCRIPTION
Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/5418

I just ran `playbooks/db_integrations.yml` but I had to manually restart PostgreSQL for the changes to take effect. It was a surprise because Geerlingguy's PostgreSQL role already deals with that in the task that changes the config (Configure host based authentication (if entries are
configured).). This task though, reported a OK:

```
TASK [geerlingguy.postgresql : Configure host based authentication (if
entries are configured).]
***********************************************************************************************
Thursday 28 May 2020  08:13:53 +0200 (0:00:03.535)       0:00:27.106
**********
[DEPRECATION WARNING]: evaluating u'postgresql_hba_entries' as a bare
variable, this behaviour will go away and you might need to add |bool to
the expression in the future. Also see
CONDITIONAL_BARE_VARS configuration toggle. This feature will be removed
in version 2.12. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
ok: [app.katuma.org]
```

Therefore, the task that actually required a restart was:

```
TASK [db_integrations : Add database user]
*****************************************************************************************************************************************************
Thursday 28 May 2020  08:13:40 +0200 (0:00:00.026)       0:00:13.590
**********
changed: [app.katuma.org]
```

This change performs that restart, relying on geerlingguy.postgresql's handler.

## Testing

we should check that indeed in a staging server without db_integrations the metabase integration can be enabled without any manual intervention.