### PR TITLE
Restart unicorn when deploying with the old method for the last time

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -114,6 +114,7 @@
     dest: "{{ current_path }}"
     state: absent
   when: current_path_stats.stat.islnk is defined and not current_path_stats.stat.islnk
+  notify: restart unicorn
 
 # Move new build into place
 


### PR DESCRIPTION
Removing the current path for the last time apparently messes with assets a bit in this case. Subsequent deployments are fine, it's just the initial one that needs a restart.