### PR TITLE
Clear tmp/cache files after precompiling

### DIFF
--- a/roles/deploy/tasks/precompile.yml
+++ b/roles/deploy/tasks/precompile.yml
@@ -37,3 +37,10 @@
   become: yes
   become_user: "{{ unicorn_user }}"
   when: check_rails_3 is failure
+
+- name: clear tmp files after asset compilation
+  command: bash -lc "bundle exec rake tmp:cache:clear"
+  args:
+    chdir: "{{ build_path }}"
+  become: yes
+  become_user: "{{ unicorn_user }}"


### PR DESCRIPTION
Possibly fixes: https://github.com/openfoodfoundation/ofn-install/issues/633

Removing files in `tmp/cache/` potentially fixes the asset fingerprint issue (not tested yet).

See: https://github.com/rails/rails/issues/14408#issuecomment-290257247