### PR TITLE
Ensure bundler has an explicit Gemfile path when used via systemd

### DIFF
--- a/roles/webserver/templates/unicorn_environment.j2
+++ b/roles/webserver/templates/unicorn_environment.j2
@@ -1,2 +1,3 @@
 RAILS_ENV={{ rails_env }}
+BUNDLE_GEMFILE={{ current_path }}/Gemfile
 {{ unicorn_env_vars | default('') }}


### PR DESCRIPTION
Related to issue #633 and PR #636

One last try with this assets issue. The previous error (https://github.com/openfoodfoundation/ofn-install/pull/636#issuecomment-638812136) has changed to one relating to bundler:

```
I, [2020-06-04T15:58:50.876913 #1624]  INFO -- : executing ["/home/openfoodnetwork/.gem/ruby/2.3.0/bin/unicorn", "-D", "-c", "/home/openfoodnetwork/apps/openfoodnetwork/shared/config/unicorn.rb", "-E", "staging", {15=>#<Kgio::UNIXServer:fd 15>}] (in /home/openfoodnetwork/apps/openfoodnetwork/releases-old/2020-06-04-155407)
/home/openfoodnetwork/.rbenv/versions/2.3.7/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- bundler/setup (LoadError)
	from /home/openfoodnetwork/.rbenv/versions/2.3.7/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
```