### PR TITLE
Set 'X-Real-IP' header when reverse-proxying from nginx to Rails app.

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -283,6 +283,7 @@ nginx_sites:
 
         gzip_proxied no-cache no-store private expired auth;
         proxy_http_version 1.1;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Recommended setting; enables us to have an accurate and straightforward way of checking the client IP addresses (in production) in Rails, with: `request.headers['X-Real-IP']`. 

Currently we get really confusing results in Bugsnag for example, where the IP always appears to be the same for each request, because it's actually the IP of the server not the client.