### PR TITLE
Don't symlink assets directory into the build

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -19,7 +19,6 @@
     state: link
     force: yes
   with_items:
-    - { src: "{{ assets_path }}", dest: "{{ build_path }}/public/assets" }
     - { src: "{{ system_path }}", dest: "{{ build_path }}/public/system" }
     - { src: "{{ images_path }}", dest: "{{ build_path }}/public/images" }
     - { src: "{{ spree_path }}", dest: "{{ build_path }}/public/spree" }


### PR DESCRIPTION
Related to: https://github.com/openfoodfoundation/openfoodnetwork/issues/5643

The result of this symlink was that precompiled assets were shared between builds in a way that they shouldn't have been, and other issues with assets (especially in Rails 4) were obfuscated; old versions of non-digest assets which technically should *not* be available, actually are available **in some cases, on some servers, in a flaky way**. :see_no_evil:

:warning: We shouldn't merge this until the other assets cleanup PRs in the main repo are all tested and merged.

Additional note: manually deploying master to a staging server with this PR makes it really obvious which things need to be fixed. Any assets that still need to be fixed should be clearly missing after deploying then clearing browser cache / using a private tab. 

#### Dev test notes

- Pull this PR
- Deploy a server with it
- Check assets (fonts, CSS, JS, images, icons, etc) are OK on the site and nothing is missing/broken. Maybe check an email as well, and look for any image/CSS issues.