### PR TITLE
Try the travis build with Ansible 2.9.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: xenial
 cache: bundler
 language: python
-python: 3.7.1
+python: 3.8
 services:
   - postgresql
 addons:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible==2.9.6
+ansible==2.9.9
 ansible-lint==4.2.0
 yamllint==1.21.0


### PR DESCRIPTION
Ignore this :+1: 

I'm just triggering a quick run of the CI build with `Ansible 2.9.9` and `Python 3.8` to see if there are any problems with using those versions for deployments...