### PR TITLE
Add image settings to ofn-install

### DIFF
--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -31,8 +31,9 @@ mail_domain: example.com
 #  OFN_FEATURE_CONNECT_AND_LEARN: "true"
 
 # Overridable Image Settings
-# attachment_url:
+# If you update attachment_styles, you will need to regenerate thumbnails. Use rake paperclip:refresh:thumbnails CLASS=Spree::Image
 # attachment_styles:
+# attachment_url:
 # attachment_path:
 # attachment_default_style:
 # attachment_default_url:

--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -29,3 +29,10 @@ mail_domain: example.com
 #
 #custom_application_env_vars: |
 #  OFN_FEATURE_CONNECT_AND_LEARN: "true"
+
+# Overridable Image Settings
+# attachment_url:
+# attachment_styles:
+# attachment_path:
+# attachment_default_style:
+# attachment_default_url:

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -29,15 +29,15 @@ google_maps_api_key:
 #s3_headers:
 #s3_protocol:
 
-# Stripe Connect API keys
+# Stripe Connect API keys, set these if you are using Stripe
 # Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings
 # Under 'Connect', the Redirect URI should be set to https://YOUR_SERVER_URL/stripe/callbacks (e.g. https://openfoodnetwork.org.uk/stripe/callbacks)
 # Under 'Webhooks', you should set up a Connect endpoint pointing to https://YOUR_SERVER_URL/stripe/webhooks e.g. (https://openfoodnetwork.org.uk/stripe/webhooks)
 # Different keys can be made for testing or live environments
-stripe_client_id: # ca_xxxx
-stripe_instance_secret_key: # sk_xxxx
-stripe_instance_publishable_key: # pk_xxxx
-stripe_endpoint_secret: # whsec_xxxx
+#stripe_client_id: # ca_xxxx
+#stripe_instance_secret_key: # sk_xxxx
+#stripe_instance_publishable_key: # pk_xxxx
+#stripe_endpoint_secret: # whsec_xxxx
 
 # Skylight's API key. This enables performance instrumentation through Skylight. See https://github.com/openfoodfoundation/openfoodnetwork/pull/2070 for details.
 #skylight_authentication: ""

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -21,6 +21,8 @@ google_maps_api_key:
 #s3_access_key:
 #s3_secret:
 #s3_images_bucket:
+#s3_headers
+#s3_protocol
 #s3_region:
 #s3_backups_bucket:
 #s3_backups_region:

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -36,7 +36,6 @@ smtp_password:
 
 # Set these if using Amazon S3 for images
 #s3_images_bucket:
-#s3_region:
 
 # Optional settings for Amazon S3 for images
 #s3_headers:

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -29,17 +29,15 @@ smtp_password:
 # Set these if using Amazon S3 for images or backups
 #s3_access_key:
 #s3_secret:
-
-# Set these if using Amazon S3 for backups
-#s3_backups_bucket:
-#s3_backups_region:
-
-# Set these if using Amazon S3 for images
+# Set this if using Amazon S3 for images:
 #s3_images_bucket:
-
-# Optional settings for Amazon S3 for images
+# Set this if using Amazon S3 for backups:
+#s3_backups_bucket:
+# Optional settings for Amazon S3 for images:
 #s3_headers:
 #s3_protocol:
+# Optional settings for Amazon S3 for backups:
+#s3_backups_region:
 
 # Stripe Connect API keys, set these if you are using Stripe
 # Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -13,6 +13,19 @@ secret_token: 'xxxxxx'
 # Create a Google Maps API key and enable Javascript and Places libraries
 google_maps_api_key:
 
+# Mail settings
+mail_host:
+mail_port:
+smtp_username:
+smtp_password:
+
+# Optional mail settings
+## Connection type 'TLS' means STARTTLS usually on port 587
+## Connection type 'SSL' means SSL/TLS usually on port 465
+# mail_secure_connection: 'TLS'
+# mails_from: from_address@example.com
+# mail_bcc: bcc_me@example.com
+
 # Set these if using Amazon S3 for images or backups
 #s3_access_key:
 #s3_secret:
@@ -42,19 +55,6 @@ google_maps_api_key:
 # Skylight's API key. This enables performance instrumentation through Skylight. See https://github.com/openfoodfoundation/openfoodnetwork/pull/2070 for details.
 #skylight_authentication: ""
 
-# Mail settings
-mail_host:
-mail_port:
-smtp_username:
-smtp_password:
-
-# Optional mail settings
-## Connection type 'TLS' means STARTTLS usually on port 587
-## Connection type 'SSL' means SSL/TLS usually on port 465
-# mail_secure_connection: 'TLS'
-# mails_from: from_address@example.com
-# mail_bcc: bcc_me@example.com
-
 # Datadog monitoring. See
 # https://github.com/openfoodfoundation/ofn-install/issues/287 for details.
 # Note we have a single OFN account where all servers send their metrics to.
@@ -65,7 +65,6 @@ smtp_password:
 # https://github.com/openfoodfoundation/ofn-install/wiki/Issue-reporting
 #
 #bugsnag_key: ''
-
 
 # Example settings for integrations like Zapier.
 # ----------------------------------------------
@@ -81,11 +80,9 @@ smtp_password:
 #db_integrations:
 #  - { user: zapier, state: present, password: incredibly_strong_password_goes_here }
 
-
 # For Datadog you will need the following:
 #
 #datadog_db_password: secure_password_goes_here
 #
 #db_integrations:
 #  - { user: datadog, state: present, password: "{{ datadog_db_password }}" }
-

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -1,12 +1,8 @@
 ---
 
 # Make sure to insert secure passwords!!
-
-
 db_password:
-
 admin_password:
-
 
 # Secret Token
 # This is required to verify session. It must be at least 30 characters and
@@ -17,15 +13,21 @@ secret_token: 'xxxxxx'
 # Create a Google Maps API key and enable Javascript and Places libraries
 google_maps_api_key:
 
-# Set these if using Amazon S3
+# Set these if using Amazon S3 for images or backups
 #s3_access_key:
 #s3_secret:
-#s3_images_bucket:
-#s3_headers
-#s3_protocol
-#s3_region:
+
+# Set these if using Amazon S3 for backups
 #s3_backups_bucket:
 #s3_backups_region:
+
+# Set these if using Amazon S3 for images
+#s3_images_bucket:
+#s3_region:
+
+# Optional settings for Amazon S3 for images
+#s3_headers:
+#s3_protocol:
 
 # Stripe Connect API keys
 # Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings

--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -22,3 +22,6 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: metabase, address: '167.99.89.242/32', auth_method: md5 }
+
+# Images settings
+attachment_path: ":rails_root/public/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/openfoodnetwork.de/config.yml
+++ b/inventory/host_vars/openfoodnetwork.de/config.yml
@@ -23,3 +23,6 @@ swapfile_size: 2G
 
 unicorn_workers: 2
 unicorn_timeout: 360
+
+# Images settings
+attachment_styles: "{\"mini\":[\"48x48#\",\"jpg\"],\"small\":[\"112x112#\",\"jpg\"],\"product\":[\"240x240>\",\"\"],\"large\":[\"600x600>\",\"jpg\"]}"

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -41,4 +41,4 @@ unicorn_env_vars: |
 
 # Images settings
 attachment_path: "public/images/spree/products/:id/:style/:basename.:extension"
-attachment_styles: "{\"mini\":[\"48x48#\",\"jpg\"],\"small\":[\"112x112#\",\"jpg\"],\"product\":[\"240x240\u003E\",\"\"],\"large\":[\"600x600\u003E\",\"jpg\"]}"
+attachment_styles: "{\"mini\":[\"48x48#\",\"jpg\"],\"small\":[\"112x112#\",\"jpg\"],\"product\":[\"240x240>\",\"\"],\"large\":[\"600x600>\",\"jpg\"]}"

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -38,3 +38,7 @@ unicorn_env_vars: |
   KILL_UNICORNS=true
   UWK_MEM_MIN=1900
   UWK_MEM_MAX=2100
+
+# Images settings
+attachment_path: "public/images/spree/products/:id/:style/:basename.:extension"
+attachment_styles: "{\"mini\":[\"48x48#\",\"jpg\"],\"small\":[\"112x112#\",\"jpg\"],\"product\":[\"240x240\u003E\",\"\"],\"large\":[\"600x600\u003E\",\"jpg\"]}"

--- a/inventory/host_vars/staging.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/staging.openfoodfrance.org/config.yml
@@ -15,3 +15,6 @@ users_sysadmin:
   - paco
   - hugo
   - filipe
+
+# Images settings
+attachment_path: "home/openfoodnetwork/apps/openfoodnetwork/current/public/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/www.openfoodfrance.org/config.yml
+++ b/inventory/host_vars/www.openfoodfrance.org/config.yml
@@ -23,3 +23,6 @@ custom_hba_entries:
 
 enable_nginx_logging: true
 enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug
+
+# Images settings
+attachment_path: "home/openfoodnetwork/apps/openfoodnetwork/current/public/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -19,3 +19,10 @@ custom_hba_entries:
 
 enable_nginx_logging: true
 enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug
+
+# Images settings
+attachment_url: "/spree/products/:id/:style/:basename.:extension"
+attachment_styles: "{\"mini\":[\"48x48#\",\"\"],\"small\":[\"100x100#\",\"\"],\"product\":[\"240x240\u003E\",\"\"],\"large\":[\"600x600\u003E\",\"\"]}"
+attachment_path: "public/spree/products/:id/:style/:basename.:extension"
+attachment_default_style: "product"
+attachment_default_url: "/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -21,8 +21,4 @@ enable_nginx_logging: true
 enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug
 
 # Images settings
-attachment_url: "/spree/products/:id/:style/:basename.:extension"
 attachment_styles: "{\"mini\":[\"48x48#\",\"\"],\"small\":[\"100x100#\",\"\"],\"product\":[\"240x240\u003E\",\"\"],\"large\":[\"600x600\u003E\",\"\"]}"
-attachment_path: "public/spree/products/:id/:style/:basename.:extension"
-attachment_default_style: "product"
-attachment_default_url: "/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -21,4 +21,4 @@ enable_nginx_logging: true
 enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug
 
 # Images settings
-attachment_styles: "{\"mini\":[\"48x48#\",\"\"],\"small\":[\"100x100#\",\"\"],\"product\":[\"240x240\u003E\",\"\"],\"large\":[\"600x600\u003E\",\"\"]}"
+attachment_styles: "{\"mini\":[\"48x48#\",\"\"],\"small\":[\"100x100#\",\"\"],\"product\":[\"240x240>\",\"\"],\"large\":[\"600x600>\",\"\"]}"

--- a/roles/app/defaults/main.yml
+++ b/roles/app/defaults/main.yml
@@ -1,4 +1,13 @@
 ---
+s3_headers: "{\"Cache-Control\":\"max-age=31557600\"}"
+s3_protocol: "https"
+
+attachment_url: "/spree/products/:id/:style/:basename.:extension"
+attachment_styles: "{\"mini\":[\"48x48\u003E\",\"\"],\"small\":[\"100x100\u003E\",\"\"],\"product\":[\"240x240\u003E\",\"\"],\"large\":[\"600x600\u003E\",\"\"]}"
+attachment_path: "public/spree/products/:id/:style/:basename.:extension"
+attachment_default_style: "product"
+attachment_default_url: "/spree/products/:id/:style/:basename.:extension"
+
 stripe_client_id:
 stripe_instance_secret_key:
 stripe_instance_publishable_key:

--- a/roles/app/defaults/main.yml
+++ b/roles/app/defaults/main.yml
@@ -3,7 +3,7 @@ s3_headers: "{\"Cache-Control\":\"max-age=31557600\"}"
 s3_protocol: "https"
 
 attachment_url: "/spree/products/:id/:style/:basename.:extension"
-attachment_styles: "{\"mini\":[\"48x48\u003E\",\"\"],\"small\":[\"100x100\u003E\",\"\"],\"product\":[\"240x240\u003E\",\"\"],\"large\":[\"600x600\u003E\",\"\"]}"
+attachment_styles: "{\"mini\":[\"48x48>\",\"\"],\"small\":[\"100x100>\",\"\"],\"product\":[\"240x240>\",\"\"],\"large\":[\"600x600>\",\"\"]}"
 attachment_path: "public/spree/products/:id/:style/:basename.:extension"
 attachment_default_style: "product"
 attachment_default_url: "/spree/products/:id/:style/:basename.:extension"

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -31,9 +31,6 @@ S3_ACCESS_KEY: {{ s3_access_key }}
 {% if s3_secret is defined %}
 S3_SECRET: {{ s3_secret }}
 {% endif %}
-{% if s3_region is defined %}
-S3_REGION: {{ s3_region }}
-{% endif %}
 {% if s3_backups_region is defined %}
 S3_BACKUPS_REGION: {{ s3_backups_region }}
 {% endif %}

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -42,6 +42,12 @@ S3_BACKUPS_BUCKET: {{ s3_backups_bucket }}
 {% if s3_images_bucket is defined %}
 S3_BUCKET: {{ s3_images_bucket }}
 {% endif %}
+{% if s3_headers is defined %}
+S3_HEADERS: {{ s3_headers }}
+{% endif %}
+{% if s3_protocol is defined %}
+S3_PROTOCOL: {{ s3_protocol }}
+{% endif %}
 
 ATTACHMENT_URL: {{ attachment_url }}
 ATTACHMENT_STYLES: {{ attachment_styles }}

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -44,10 +44,10 @@ S3_BACKUPS_BUCKET: {{ s3_backups_bucket }}
 S3_BUCKET: {{ s3_images_bucket }}
 {% endif %}
 {% if s3_headers is defined %}
-S3_HEADERS: {{ s3_headers }}
+S3_HEADERS: {{ s3_headers | "{\"Cache-Control\":\"max-age=31557600\"}" }}
 {% endif %}
 {% if s3_protocol is defined %}
-S3_PROTOCOL: {{ s3_protocol }}
+S3_PROTOCOL: {{ s3_protocol | "https" }}
 {% endif %}
 
 ATTACHMENT_URL: {{ attachment_url | "/spree/products/:id/:style/:basename.:extension" }}

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -40,18 +40,15 @@ S3_BACKUPS_BUCKET: {{ s3_backups_bucket }}
 {% if s3_images_bucket is defined %}
 S3_BUCKET: {{ s3_images_bucket }}
 {% endif %}
-{% if s3_headers is defined %}
-S3_HEADERS: {{ s3_headers | "{\"Cache-Control\":\"max-age=31557600\"}" }}
-{% endif %}
-{% if s3_protocol is defined %}
-S3_PROTOCOL: {{ s3_protocol | "https" }}
-{% endif %}
 
-ATTACHMENT_URL: {{ attachment_url | "/spree/products/:id/:style/:basename.:extension" }}
-ATTACHMENT_STYLES: {{ attachment_styles | "{\"mini\":[\"48x48\u003E\",\"\"],\"small\":[\"100x100\u003E\",\"\"],\"product\":[\"240x240\u003E\",\"\"],\"large\":[\"600x600\u003E\",\"\"]}" }}
-ATTACHMENT_PATH: {{ attachment_path | "public/spree/products/:id/:style/:basename.:extension" }}
-ATTACHMENT_DEFAULT_STYLE: {{ attachment_default_style | "product" }}
-ATTACHMENT_DEFAULT_URL: {{ attachment_default_url | "/spree/products/:id/:style/:basename.:extension" }}
+S3_HEADERS: {{ s3_headers }}
+S3_PROTOCOL: {{ s3_protocol }}
+
+ATTACHMENT_URL: {{ attachment_url }}
+ATTACHMENT_STYLES: {{ attachment_styles }}
+ATTACHMENT_PATH: {{ attachment_path }}
+ATTACHMENT_DEFAULT_STYLE: {{ attachment_default_style }}
+ATTACHMENT_DEFAULT_URL: {{ attachment_default_url }}
 
 STRIPE_CLIENT_ID: {{ stripe_client_id }}
 STRIPE_INSTANCE_SECRET_KEY: {{ stripe_instance_secret_key }}

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -43,6 +43,12 @@ S3_BACKUPS_BUCKET: {{ s3_backups_bucket }}
 S3_BUCKET: {{ s3_images_bucket }}
 {% endif %}
 
+ATTACHMENT_URL: {{ attachment_url }}
+ATTACHMENT_STYLES: {{ attachment_styles }}
+ATTACHMENT_PATH: {{ attachment_path }}
+ATTACHMENT_DEFAULT_STYLE: {{ attachment_default_style }}
+ATTACHMENT_DEFAULT_URL: {{ attachment_default_url }}
+
 STRIPE_CLIENT_ID: {{ stripe_client_id }}
 STRIPE_INSTANCE_SECRET_KEY: {{ stripe_instance_secret_key }}
 STRIPE_INSTANCE_PUBLISHABLE_KEY: {{ stripe_instance_publishable_key }}

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -24,6 +24,7 @@ ADMIN_PASSWORD: {{ admin_password }}
 {% if enable_rails_apm is defined %}
 DATADOG_RAILS_APM: {{ enable_rails_apm }}
 {% endif %}
+
 {% if s3_access_key is defined %}
 S3_ACCESS_KEY: {{ s3_access_key }}
 {% endif %}
@@ -49,11 +50,11 @@ S3_HEADERS: {{ s3_headers }}
 S3_PROTOCOL: {{ s3_protocol }}
 {% endif %}
 
-ATTACHMENT_URL: {{ attachment_url }}
-ATTACHMENT_STYLES: {{ attachment_styles }}
-ATTACHMENT_PATH: {{ attachment_path }}
-ATTACHMENT_DEFAULT_STYLE: {{ attachment_default_style }}
-ATTACHMENT_DEFAULT_URL: {{ attachment_default_url }}
+ATTACHMENT_URL: {{ attachment_url | "/spree/products/:id/:style/:basename.:extension" }}
+ATTACHMENT_STYLES: {{ attachment_styles | "{\"mini\":[\"48x48\u003E\",\"\"],\"small\":[\"100x100\u003E\",\"\"],\"product\":[\"240x240\u003E\",\"\"],\"large\":[\"600x600\u003E\",\"\"]}" }}
+ATTACHMENT_PATH: {{ attachment_path | "public/spree/products/:id/:style/:basename.:extension" }}
+ATTACHMENT_DEFAULT_STYLE: {{ attachment_default_style | "product" }}
+ATTACHMENT_DEFAULT_URL: {{ attachment_default_url | "/spree/products/:id/:style/:basename.:extension" }}
 
 STRIPE_CLIENT_ID: {{ stripe_client_id }}
 STRIPE_INSTANCE_SECRET_KEY: {{ stripe_instance_secret_key }}


### PR DESCRIPTION
#### What? Why?
To remove the page admin/image_settings/edit from OFN ([this PR](https://github.com/openfoodfoundation/openfoodnetwork/pull/5729)), we need to add an alternative way to change and track these settings.
Some are already in ofn-secrets:
s3_access_key
s3_secret
s3_images_bucket (which is converted to s3_bucket)

To keep consistency, in this PR, we add the 2 remaining S3 entries to ofn-secrets (to the example file) where the other ones are. It looks like this:
s3_headers: "{\"Cache-Control":"max-age=31557600\"}"
s3_protocol: "https"

In this PR we also set defaults for all image settings and copy custom settings from all servers to each server config.yml file.


#### What should we test?
I provisioned staging FR with this PR and I do get the images settings in application.yml as well as the custom ATTACHEMENT_PATH :+1: 

#### Release notes
Changelog Category: Changed
Image settings can now be set through ofn-install.