### PR TITLE
Updated host vars for AU and Katuma

### DIFF
--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -22,5 +22,3 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: metabase, address: '167.99.89.242/32', auth_method: md5 }
-
-disable_datadog: true

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -17,7 +17,7 @@ certbot_domains:
 
 # Size in bytes. You can also use units like 1G, 512MiB or 1000KB. See: `man fallocate`
 # The default is `false`, not installing a swapfile.
-swapfile_size: 8G
+swapfile_size: 4G
 
 unicorn_timeout: 360
 unicorn_workers: 3


### PR DESCRIPTION
I decreased the swap size for Australia because we don't need that much swap and we need more disk space.

When I last provisioned Katuma, I also encountered an error trying to remove Datadog even though it's gone already. So I took that one out as well.