### PR TITLE
use US-specific locale for translating strings

### DIFF
--- a/inventory/group_vars/us.yml
+++ b/inventory/group_vars/us.yml
@@ -3,7 +3,7 @@
 checkout_zone: USA
 country_code: US
 currency: USD
-locale: en
+locale: en_US
 language: en_US.UTF8
 language_packages:
   - language-pack-en-base

--- a/inventory/group_vars/us.yml
+++ b/inventory/group_vars/us.yml
@@ -4,6 +4,7 @@ checkout_zone: USA
 country_code: US
 currency: USD
 locale: en_US
+available_locales: en_US
 language: en_US.UTF8
 language_packages:
   - language-pack-en-base


### PR DESCRIPTION
This fixes issue 6003 in the [openfoodnetwork repo](https://github.com/openfoodfoundation/openfoodnetwork/issues/6003) from Laurie. 

It should be pretty straightforward; I don't know what the process for testing something like this would look like, if we should deploy it to a staging server first to make sure nothing bombs out (what if I'd mistyped en_US as en_USA for example and the en_USA.yml file doesn't exist, for example?)

The other consideration is whether transifex has been keeping en_US.yml up to date; I did `diff en.yml en_US.yml` and took a quick glance through and nothing jumped out as wrong, mostly swapping "organisation" for "organization" and things like that. 