### PR TITLE
Add new configuration for new FR_prod domain

### DIFF
--- a/inventory/host_vars/www.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/www.coopcircuits.fr/config.yml
@@ -1,0 +1,25 @@
+---
+
+domain: www.coopcircuits.fr
+host_id: fr-prod
+rails_env: production
+
+admin_email: admin@coopcircuits.fr
+
+mail_domain: coopcircuits.fr
+
+unicorn_timeout: 240
+unicorn_workers: 4
+
+certbot_domains:
+  - www.coopcircuits.fr
+  - coopcircuits.fr
+
+postgres_listen_addresses:
+  - '*'
+
+custom_hba_entries:
+  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+
+enable_nginx_logging: true
+enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -118,7 +118,7 @@ es-staging
 # France
 
 [fr-prod]
-www.openfoodfrance.org ansible_host=51.68.226.206
+www.coopcircuits.fr ansible_host=51.68.226.206
 
 [fr-staging]
 staging.coopcircuits.fr ansible_host=149.202.55.45


### PR DESCRIPTION
This configuration will allow the new domain for FR_prod, coopcircuits.fr.

This PR should be merged on Wednesday, 23rd of September evening, just before the migration process.