### PR TITLE
Update US config to allow zapier access

### DIFF
--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -24,4 +24,5 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - { type: host, database: all, user: all, address: '0.0.0.0/0', auth_method: md5 }
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }


### PR DESCRIPTION
I did some digging through old emails about getting the USA server connected to Zapier. This thread with @Matt-Yorkley in Slack came up: https://openfoodnetwork.slack.com/archives/CJPMYTDJM/p1570784226004600

Which points to this answer on Stack Overflow: https://stackoverflow.com/a/32413170/374873

I looked at our pg_hba.conf file and saw that we're already adding a custom hba entry in the US [config.yml file](https://github.com/openfoodfoundation/ofn-install/blob/0d4924ca6eb2f7811023afc49c2b860c15ca281f/inventory/host_vars/openfoodnetwork.net/config.yml#L27). The answer on SO suggests that another line should be added:

`host    all             all             0.0.0.0/0               md5` 

I do see that there's already this line in the pg_hba.conf file:

`host all all ::1/128   md5`

which seems like it should do something very similar, but my networking knowledge isn't extensive enough to know for sure that it would do exactly the same thing, so I think it'd be worth trying this out. 

