### PR TITLE
Add image settings to hosts missing them

### DIFF
--- a/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
@@ -18,3 +18,6 @@ unicorn_timeout: 120
 # Size in bytes. You can also use units like 1G, 512MiB or 1000KB. See: `man fallocate`
 # The default is `false`, not installing a swapfile.
 swapfile_size: 1G
+
+# Images settings
+attachment_path: "public/images/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/staging2.openfood.com.au/config.yml
+++ b/inventory/host_vars/staging2.openfood.com.au/config.yml
@@ -1,7 +1,0 @@
----
-
-domain: staging2.openfoodnetwork.com.au
-host_id: au-staging
-rails_env: staging
-
-admin_email:

--- a/inventory/host_vars/staging2.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging2.openfoodnetwork.org.uk/config.yml
@@ -1,7 +1,0 @@
----
-
-domain: staging2.openfoodnetwork.org.uk
-host_id: uk-staging
-rails_env: staging
-
-admin_email: dev.ofnuk@gmail.com

--- a/inventory/host_vars/www.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.au/config.yml
@@ -1,5 +1,0 @@
----
-
-domain: www.openfoodnetwork.org.au
-host_id: au-prod
-rails_env: production


### PR DESCRIPTION
Testing openfoodfoundation/openfoodnetwork#5729 the images were broken and I noticed that the attachment path had changed. I checked all hosts managed by the global community and added the path were it was missing and different to the default.

This should be merged before openfoodfoundation/openfoodnetwork#5729 so that we can test with the right config on any staging server.

Outdated configs were removed to reduce the amount of files which may need adjustments.