### PR TITLE
Minor tweak: ignore missing log files for pg queries

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -171,6 +171,7 @@ logrotate_applications:
         options:
           - daily         # run daily
           - rotate 0      # don't rotate files
+          - missingok     # ignore missing logs
           - nocreate      # don't replace log files
         lastaction:       # delete log files older than 1 day
           - "find /var/log/pg_log/ -name '*.log' -mtime +1 -exec rm {};"


### PR DESCRIPTION
I noticed some minor errors related to this whilst debugging something else... in most configurations the pg_log file doesn't exist so we should tell logrotate to ignore it in that case.