### PR TITLE
Whitelist HTTP methods

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -231,10 +231,7 @@ nginx_acme_challenge_config: |+
     root /etc/letsencrypt/webrootauth;
   }
 
-nginx_valid_methods: |+
-  limit_except GET POST PUT PATCH DELETE OPTIONS {
-    deny all;
-  }
+nginx_valid_methods: limit_except GET POST PUT PATCH DELETE OPTIONS { deny all; }
 
 nginx_sites:
   default:
@@ -253,7 +250,6 @@ nginx_sites:
 
   ofn_80:
     - |
-      {{ nginx_valid_methods }}
       listen 80;
       listen [::]:80;
       server_name {{ certbot_domains | default([domain]) | join(' ') }};
@@ -264,12 +260,12 @@ nginx_sites:
       {{ nginx_acme_challenge_config }}
 
       location / {
+        {{ nginx_valid_methods }}
         return 301 https://$host$request_uri;
       }
 
   ofn_443:
     - |
-      {{ nginx_valid_methods }}
       listen 443 ssl http2;
       listen [::]:443 ssl http2;
       server_name {{ certbot_domains | default([domain]) | join(' ') }};
@@ -290,6 +286,8 @@ nginx_sites:
 
       try_files $uri/index.html $uri @unicorn;
       location @unicorn {
+        {{ nginx_valid_methods }}
+
         if (-f /etc/nginx/maintenance.html) {
           return 503;
         }
@@ -305,6 +303,7 @@ nginx_sites:
       }
 
       location ~ ^/(assets)/ {
+        {{ nginx_valid_methods }}
         gzip_static on;
         brotli_static on;
         expires max;
@@ -315,6 +314,7 @@ nginx_sites:
       error_page 503 @maintenance;
 
       location @maintenance {
+        {{ nginx_valid_methods }}
         root /etc/nginx;
         try_files /maintenance.html =503;
       }

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -231,6 +231,11 @@ nginx_acme_challenge_config: |+
     root /etc/letsencrypt/webrootauth;
   }
 
+nginx_valid_methods: |+
+  limit_except GET POST PUT DELETE OPTIONS {
+    deny all;
+  }
+
 nginx_sites:
   default:
     - |
@@ -248,6 +253,7 @@ nginx_sites:
 
   ofn_80:
     - |
+      {{ nginx_valid_methods }}
       listen 80;
       listen [::]:80;
       server_name {{ certbot_domains | default([domain]) | join(' ') }};
@@ -263,6 +269,7 @@ nginx_sites:
 
   ofn_443:
     - |
+      {{ nginx_valid_methods }}
       listen 443 ssl http2;
       listen [::]:443 ssl http2;
       server_name {{ certbot_domains | default([domain]) | join(' ') }};

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -232,7 +232,7 @@ nginx_acme_challenge_config: |+
   }
 
 nginx_valid_methods: |+
-  limit_except GET POST PUT DELETE OPTIONS {
+  limit_except GET POST PUT PATCH DELETE OPTIONS {
     deny all;
   }
 


### PR DESCRIPTION
Adds HTTP method whitelisting to our nginx configs :muscle:

Any request from a browser or as part of an API call will reasonably declare one of the standard HTTP methods. We get a large volume of requests with no valid HTTP method declared, and they generally look pretty nasty. Examples of the kind of thing that gets sent with no valid HTTP method (and usually no user-agent header either):

![Screenshot from 2020-10-16 22-40-07](https://user-images.githubusercontent.com/9029026/96312472-fc638f80-100b-11eb-854e-ee25b8b627ad.png)

For anyone that likes trawling log files, here's what all of our nginx traffic from the last 7 days for UK and France looks like when you filter out the requests with valid HTTP methods: [nasty logs](https://app.datadoghq.com/logs?cols=%40response_time%2C%40http.status_code%2C%40http.url_details.path%2C%40http.method%2C%40http.useragent&from_ts=1602279149870&index=&live=true&messageDisplay=inline&query=-%40http.method%3A%28GET%20OR%20POST%20OR%20PUT%20OR%20DELETE%20OR%20HEAD%20OR%20OPTIONS%29%20%40http.status_code%3A400&stream_sort=desc&to_ts=1602883949870)



