### PR TITLE
Fix broken image paths

### DIFF
--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -22,6 +22,3 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: metabase, address: '167.99.89.242/32', auth_method: md5 }
-
-# Images settings
-attachment_path: ":rails_root/public/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/www.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/www.coopcircuits.fr/config.yml
@@ -23,3 +23,5 @@ custom_hba_entries:
 
 enable_nginx_logging: true
 enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug
+
+attachment_path: "home/openfoodnetwork/apps/openfoodnetwork/current/public/spree/products/:id/:style/:basename.:extension"

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -45,7 +45,7 @@ S3_HEADERS: {{ s3_headers }}
 S3_PROTOCOL: {{ s3_protocol }}
 
 ATTACHMENT_URL: {{ attachment_url }}
-ATTACHMENT_PATH: {{ attachment_path }}
+ATTACHMENT_PATH: "{{ attachment_path }}"
 
 STRIPE_CLIENT_ID: {{ stripe_client_id }}
 STRIPE_INSTANCE_SECRET_KEY: {{ stripe_instance_secret_key }}


### PR DESCRIPTION
We had some post-deployment fun this morning with broken image paths on `es-prod` and `fr-prod` due to two separate issues.

The updated values here are what I've already applied in production on both servers to fix them.

I've also removed a value here as we don't need it. See commit messages for details.