### PR TITLE
Improve nginx stub_status config

### DIFF
--- a/roles/datadog/templates/status.conf.j2
+++ b/roles/datadog/templates/status.conf.j2
@@ -1,10 +1,7 @@
 server {
-  listen 81;
+  listen 127.0.0.1:81;
   server_name localhost;
-
   access_log off;
-  allow 127.0.0.1;
-  deny all;
 
   location /nginx_status {
     stub_status;


### PR DESCRIPTION
This status page is only accessed internally for stats collection. It shouldn't be accessible externally. The original config here meant that nginx was binding on 0.0.0.0 port 81, which is not necessary. External access to the port was producing a 403/Forbidden response (which is not too bad), but it shouldn't leave that port open at all.