### PR TITLE
Add new attachment URLs for all servers using S3

### DIFF
--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -41,3 +41,4 @@ unicorn_env_vars: |
 
 # Images settings
 attachment_path: "public/images/spree/products/:id/:style/:basename.:extension"
+attachment_url: ofn_production.s3.us-east-1.amazonaws.com

--- a/inventory/host_vars/staging.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/staging.coopcircuits.fr/config.yml
@@ -14,3 +14,5 @@ users_sysadmin:
   - "{{ core_devs }}"
   - paco
   - filipe
+
+attachment_url: ccs-ofn-staging.s3.eu-west-3.amazonaws.com

--- a/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
@@ -21,3 +21,4 @@ swapfile_size: 1G
 
 # Images settings
 attachment_path: "public/images/spree/products/:id/:style/:basename.:extension"
+attachment_url: ofn-staging.s3.us-east-1.amazonaws.com

--- a/inventory/host_vars/www.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/www.coopcircuits.fr/config.yml
@@ -25,3 +25,4 @@ enable_nginx_logging: true
 enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug
 
 attachment_path: "home/openfoodnetwork/apps/openfoodnetwork/current/public/spree/products/:id/:style/:basename.:extension"
+attachment_url: ofn-prod.s3.us-east-1.amazonaws

--- a/inventory/host_vars/www.openfoodnetwork.be/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.be/config.yml
@@ -11,3 +11,5 @@ mail_domain: openfoodnetwork.be
 certbot_domains:
   - www.openfoodnetwork.be
   - openfoodnetwork.be
+
+attachment_url: ofn-belgium.s3.us-east-1.amazonaws.com

--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -19,3 +19,5 @@ custom_hba_entries:
 
 enable_nginx_logging: true
 enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug
+
+attachment_url: ofn-uk-production.s3.us-east-1.amazonaws.com


### PR DESCRIPTION
This PR updates the config for all servers using S3 to store images. The url is now the S3 URL including the bucket name and the region. See original issue https://github.com/openfoodfoundation/openfoodnetwork/issues/4177 and the main PR https://github.com/openfoodfoundation/openfoodnetwork/pull/6258