### PR TITLE
Allow MAIL_AUTH_TYPE to be set

### DIFF
--- a/roles/unicorn_user/templates/defaults.j2
+++ b/roles/unicorn_user/templates/defaults.j2
@@ -6,6 +6,9 @@ MAIL_PORT={{ mail_port }}
 {% if mail_secure_connection is defined %}
   MAIL_SECURE_CONNECTION={{ mail_secure_connection  }}
 {% endif %}
+{% if mail_auth_type is defined %}
+  MAIL_AUTH_TYPE={{ mail_auth_type }}
+{% endif %}
 SMTP_USERNAME={{ smtp_username }}
 SMTP_PASSWORD={{ smtp_password }}
 {% if mails_from is defined %}


### PR DESCRIPTION
Allows setting `mail_auth_type`. This is a standard mail config setting, but was previously not configurable via ofn-install and was just set to a hard-coded default.

Needed for Sendgrid API authentication. Tested and working in UK Staging :heavy_check_mark: 

Twinned with: https://github.com/openfoodfoundation/openfoodnetwork/issues/6365

To use the Sendgrid API method (after these two PRs are merged) the new settings are:

```yaml
mail_auth_type: "plain"
smtp_username: "apikey"
smtp_password: "<api-key-from-sengrid-account>"
```


