### PR TITLE
Fix typo in fr-prod attachment_url

### DIFF
--- a/inventory/host_vars/www.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/www.coopcircuits.fr/config.yml
@@ -25,4 +25,4 @@ enable_nginx_logging: true
 enable_rails_apm: "true" # has to be explicitly defined as a string due to some datadog bug
 
 attachment_path: "home/openfoodnetwork/apps/openfoodnetwork/current/public/spree/products/:id/:style/:basename.:extension"
-attachment_url: ofn-prod.s3.us-east-1.amazonaws
+attachment_url: ofn-prod.s3.us-east-1.amazonaws.com


### PR DESCRIPTION
Fixing a quick typo in the configs so the poor sucker** that deploys to production next Tuesday doesn't have any nasty surprises with all images suddenly being broken on `fr-prod`.

See https://github.com/openfoodfoundation/ofn-install/pull/667/files for reference.

\** it's me this week :sweat_smile: 