### PR TITLE
Inline task from dumb precompile.yml

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -113,10 +113,12 @@
     - skip_ansible_lint
   notify: restart unicorn
 
-# Precompile assets
-
-- name: precompile assets
-  import_tasks: precompile.yml
+- name: precompile assets # noqa 301
+  command: bash -lc "bundle exec rake assets:precompile RAILS_ENV={{ rails_env }}"
+  args:
+    chdir: "{{ build_path }}"
+  become: yes
+  become_user: "{{ unicorn_user }}"
 
 # Note: this task can be removed after all servers have been provisioned and deployed
 - name: delete current path unless it's a symlink

--- a/roles/deploy/tasks/precompile.yml
+++ b/roles/deploy/tasks/precompile.yml
@@ -1,8 +1,0 @@
----
-
-- name: precompile assets # noqa 301
-  command: bash -lc "bundle exec rake assets:precompile RAILS_ENV={{ rails_env }}"
-  args:
-    chdir: "{{ build_path }}"
-  become: yes
-  become_user: "{{ unicorn_user }}"


### PR DESCRIPTION
We extracted it into a separate file when upgrading to Rails 4 as asset precompilation changed from two to one rake task, adding a conditional to support both Rails versions now that it's back to a plain simple ansible task there's no need for the indirection.