### PR TITLE
Add ruby 2.4.4 to list of ruby versions so we can gracefully upgrade servers

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -50,10 +50,11 @@ swapfile_size: false
 
 #----------------------------------------------------------------------
 # Rails variables
-ruby_version: 2.3.7
+ruby_version: 2.4.4
 
 ruby_versions:
   - version: 2.3.7
+  - version: 2.4.4
 
 env:
   RAILS_ENV: "{{ rails_env }}"


### PR DESCRIPTION
This was done for 2.3.7 here: https://github.com/openfoodfoundation/ofn-install/pull/549

This is needed for https://github.com/openfoodfoundation/openfoodnetwork/pull/6441