### PR TITLE
Enable Datadog's APM for CA production

### DIFF
--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -19,3 +19,5 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+
+enable_rails_apm: "true"


### PR DESCRIPTION
Closes https://github.com/openfoodfoundation/ofn-install/issues/679. It requires https://github.com/openfoodfoundation/ofn-secrets/pull/49 first.