### PR TITLE
Systemd service updates: boot order, timeouts, permissions

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -12,7 +12,6 @@
     - { src: "delayed_job.service.j2", dest: "/etc/systemd/system/delayed_job_{{ app }}.service" }
   register: unicorn_service_files
   notify:
-    - restart nginx
     - restart unicorn if running
   tags: init
 

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -5,8 +5,6 @@
     src={{ item.src }}
     dest={{ item.dest }}
     mode="0644"
-    owner={{ unicorn_user }}
-    group={{ unicorn_user }}
   become: yes
   with_items:
     - { src: "unicorn.service.j2", dest: "/etc/systemd/system/unicorn_{{ app }}.service" }

--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -4,7 +4,7 @@
   template:
     src={{ item.src }}
     dest={{ item.dest }}
-    mode="0744"
+    mode="0644"
     owner={{ unicorn_user }}
     group={{ unicorn_user }}
   become: yes
@@ -22,7 +22,7 @@
   template:
     src: unicorn.rb.j2
     dest: "{{ config_path }}/unicorn.rb"
-    mode: 0744
+    mode: 0644
     owner: "{{ unicorn_user }}"
     group: "{{ unicorn_user }}"
   become: yes

--- a/roles/webserver/templates/delayed_job.service.j2
+++ b/roles/webserver/templates/delayed_job.service.j2
@@ -2,6 +2,7 @@
 
 [Unit]
 Description=Open Food Network delayed_job
+After=memcached.service postgresql.service
 
 [Service]
 Type=forking

--- a/roles/webserver/templates/unicorn.service.j2
+++ b/roles/webserver/templates/unicorn.service.j2
@@ -17,5 +17,7 @@ ExecStart={{ bundle_path }} exec --keep-file-descriptors unicorn -D -c {{ unicor
 ExecStop=/bin/kill -QUIT $MAINPID
 ExecReload=/bin/kill -USR2 $MAINPID
 
+TimeoutStartSec=300
+
 [Install]
 WantedBy=multi-user.target

--- a/roles/webserver/templates/unicorn.service.j2
+++ b/roles/webserver/templates/unicorn.service.j2
@@ -2,6 +2,7 @@
 
 [Unit]
 Description=Open Food Network unicorn server
+After=memcached.service postgresql.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Fixes #680.

These changes ensure that unicorn and delayed job are booting at the right time without errors. I also noticed a few other bits to improve, including a security concern.

I tested this on au-staging and it seems to work well.