### PR TITLE
Quick playbook for fixing all broken/orphaned T&C PDFs

### DIFF
--- a/playbooks/migrate_pdfs.yml
+++ b/playbooks/migrate_pdfs.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Migrate PDFs
+  hosts: ofn_servers
+  strategy: free
+  remote_user: "{{ user }}"
+
+  tasks:
+    - name: find PDF file paths
+      shell: "ls {{ releases_path }}/*/public/files/enterprises/terms_and_conditions/*/*.pdf"
+      become: yes
+      register: pdf_paths
+
+    - name: create required subdirectories recursively
+      file:
+        path: "{{ files_path }}/enterprises/terms_and_conditions/{{ item.split('terms_and_conditions')[1] | dirname }}"
+        state: directory
+        owner: "{{ unicorn_user }}"
+        group: "{{ unicorn_user }}"
+        recurse: yes
+      with_items: "{{ pdf_paths.stdout_lines }}"
+      become: yes
+
+    - name: copy PDFs to their new paths
+      copy:
+        src: "{{ item }}"
+        dest: "{{ files_path }}/enterprises/terms_and_conditions{{ item.split('terms_and_conditions')[1] }}"
+        remote_src: yes
+        owner: "{{ unicorn_user }}"
+        group: "{{ unicorn_user }}"
+      with_items: "{{ pdf_paths.stdout_lines }}"
+      become: yes


### PR DESCRIPTION
Related to openfoodfoundation/openfoodnetwork#6530

Finds orphaned T&C PDFs in the backup paths for previous releases and copies them to the new shared path where they will be accessible between deployments.

See new PDF filepath details in #685

We probably don't need to merge this, we can just run the playbook once and we won't need it again...

Tested on UK Staging. PDFs uploaded in several previous deployments were all correctly copied into the new shared directory, and became available again. :heavy_check_mark: 