### PR TITLE
Enable Datadog's APM for US production

### DIFF
--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -25,3 +25,5 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+
+enable_rails_apm: "true"


### PR DESCRIPTION
Closes #687. It requires https://github.com/openfoodfoundation/ofn-secrets/pull/50 first.