### PR TITLE
Add custom HTTP header to track request queuing

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -301,6 +301,7 @@ nginx_sites:
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Request-Start "t=${msec}";
         proxy_redirect off;
         proxy_pass http://unicorn;
       }


### PR DESCRIPTION
This enables Datadog's HTTP request queue tracking. See https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#http-request-queuing.