### PR TITLE
Update security groups to reflect current reality

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -200,10 +200,7 @@ memcached_value_max_megabytes: 4
 core_devs:
   - maikel
   - pau
-  - enricostn
-  - luis
   - matt
-  - kristina
   - andy
 
 #----------------------------------------------------------------------

--- a/inventory/group_vars/au.yml
+++ b/inventory/group_vars/au.yml
@@ -18,5 +18,3 @@ developer_email: maikel@openfoodnetwork.org.au
 # Users listed here will have their key from /files/keys added to the unicorn_user
 users_sysadmin:
   - "{{ core_devs }}"
-  - rob
-  - rohan

--- a/inventory/group_vars/ca.yml
+++ b/inventory/group_vars/ca.yml
@@ -19,4 +19,3 @@ developer_email: admin@openfoodnetwork.ca
 # Users listed here will have their key from /files/keys added to the unicorn_user
 users_sysadmin:
   - "{{ core_devs }}"
-  - hugo

--- a/inventory/group_vars/es.yml
+++ b/inventory/group_vars/es.yml
@@ -18,3 +18,4 @@ developer_email: info@coopdevs.org
 users_sysadmin:
   - "{{ core_devs }}"
   - dani
+  - enricostn

--- a/inventory/group_vars/fr.yml
+++ b/inventory/group_vars/fr.yml
@@ -20,4 +20,3 @@ developer_email: admin@coopcircuits.fr
 users_sysadmin:
   - "{{ core_devs }}"
   - paco
-  - hugo


### PR DESCRIPTION
I wanted to remove myself from having access to servers.
Then I decided to update a few more users to keep the current global sysadmin group current. It's just a proposal. We can keep as is if anyone disagrees with the changes. 