### PR TITLE
Use Katuma's admin email instead of Coopdevs'

### DIFF
--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -3,7 +3,7 @@ domain: app.katuma.org
 host_id: es-prod
 rails_env: production
 
-admin_email: info@coopdevs.org
+admin_email: info@katuma.org
 
 mail_domain: katuma.org
 

--- a/inventory/host_vars/staging.katuma.org/config.yml
+++ b/inventory/host_vars/staging.katuma.org/config.yml
@@ -2,7 +2,7 @@
 domain: staging.katuma.org
 host_id: es-staging
 rails_env: staging
-admin_email: info@coopdevs.org
+admin_email: info@katuma.org
 
 mail_domain: katuma.org
 


### PR DESCRIPTION
Enrico freaked out when he saw 10 test emails in Coopdevs' inbox. These and other admin-related better go to Katuma's inbox.