### PR TITLE
Decrease Unicorn and Nginx timeout to 60s

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -186,7 +186,7 @@ unicorn_log: "{{ log_path }}/unicorn.log"
 unicorn_pid: "{{ pid_path }}/unicorn.pid"
 unicorn_sock: "{{ sock_path }}/unicorn.{{ app }}.sock"
 unicorn_workers: 2
-unicorn_timeout: 30
+unicorn_timeout: 60
 unicorn_env_vars: |
   KILL_UNICORNS=true
 

--- a/inventory/host_vars/openfoodbrasil.com.br/config.yml
+++ b/inventory/host_vars/openfoodbrasil.com.br/config.yml
@@ -7,7 +7,6 @@ admin_email: administrativo@openfoodbrasil.com.br
 mail_domain: openfoodbrasil.com.br
 
 swapfile_size: 2G
-unicorn_timeout: 120
 
 certbot_domains:
   - openfoodbrasil.com.br

--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -8,7 +8,6 @@ admin_email: admin@openfoodnetwork.ca
 mail_domain: openfoodnetwork.ca
 
 swapfile_size: 2G
-unicorn_timeout: 360
 
 certbot_domains:
   - openfoodnetwork.ca

--- a/inventory/host_vars/openfoodnetwork.de/config.yml
+++ b/inventory/host_vars/openfoodnetwork.de/config.yml
@@ -22,4 +22,3 @@ swapfile_size: 2G
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 unicorn_workers: 2
-unicorn_timeout: 360

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -19,7 +19,6 @@ certbot_domains:
 # The default is `false`, not installing a swapfile.
 swapfile_size: 4G
 
-unicorn_timeout: 360
 unicorn_workers: 3
 
 # Enable external database access for third party integrations

--- a/inventory/host_vars/staging.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/staging.coopcircuits.fr/config.yml
@@ -8,8 +8,6 @@ admin_email: admin@coopcircuits.fr
 
 mail_domain: coopcircuits.fr
 
-unicorn_timeout: 120
-
 users_sysadmin:
   - "{{ core_devs }}"
   - paco

--- a/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
@@ -13,7 +13,6 @@ available_locales: en,fr,es
 
 # Depending on the resources of your server, you may want to adjust these.
 unicorn_workers: 1
-unicorn_timeout: 120
 
 # Size in bytes. You can also use units like 1G, 512MiB or 1000KB. See: `man fallocate`
 # The default is `false`, not installing a swapfile.

--- a/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
@@ -6,8 +6,6 @@ rails_env: staging
 
 admin_email: dev.ofnuk@gmail.com
 
-unicorn_timeout: 120
-
 users_sysadmin:
   - "{{ core_devs }}"
   - lindhop

--- a/inventory/host_vars/www.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/www.coopcircuits.fr/config.yml
@@ -8,7 +8,6 @@ admin_email: admin@coopcircuits.fr
 
 mail_domain: coopcircuits.fr
 
-unicorn_timeout: 240
 unicorn_workers: 4
 
 certbot_domains:

--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -5,7 +5,6 @@ host_id: uk-prod
 rails_env: production
 
 unicorn_workers: 5
-unicorn_timeout: 720
 
 certbot_domains:
   - www.openfoodnetwork.org.uk


### PR DESCRIPTION
This seems to be Nginx default and a much more sensible value. Having a single user running a request for 9min, putting the system on fire, blocking anyone else from using it, etc. it's far worse for the business than just killing the request. Better to have a pissed off user than the service down.

Metrics show that response times >1min happen around 8 times every couple of days.

![Screenshot from 2021-01-26 11-17-41](https://user-images.githubusercontent.com/762088/105835209-d024bb00-5fcb-11eb-8673-32b25a27734f.png)
