### PR TITLE
Don't use swap in CA production

### DIFF
--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -7,7 +7,6 @@ rails_env: production
 admin_email: admin@openfoodnetwork.ca
 mail_domain: openfoodnetwork.ca
 
-swapfile_size: 2G
 unicorn_timeout: 360
 
 certbot_domains:


### PR DESCRIPTION
The new CA server has around 5.5Gb of free RAM so there's no point in having any swap, which when used, slows things down a few orders of magnitude.

This will hopefully mitigate https://github.com/openfoodfoundation/openfoodnetwork/issues/6802 but won't solve it.