### PR TITLE
Added became root on db_tranfert task to grant access of private key …

### DIFF
--- a/roles/db_transfer/tasks/main.yml
+++ b/roles/db_transfer/tasks/main.yml
@@ -30,6 +30,8 @@
   vars:
     ansible_ssh_extra_args: '-o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=600'
   delegate_to: "{{ groups[rsync_to][0] }}"
+  become: yes
+  become_user: root
 
 - name: move to postgres-owned path # noqa 301
   command: mv {{ admin_dump_path }} {{ postgres_dump_path }}


### PR DESCRIPTION
…in /root/.ssh/ during the rsync.

This is a minor fix for the db_transfert playbook.