### PR TITLE
Rename subdomain for USA migration

### DIFF
--- a/inventory/host_vars/migration.openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/migration.openfoodnetwork.net/config.yml
@@ -1,6 +1,6 @@
 ---
 
-domain: migrate.openfoodnetwork.net
+domain: migration.openfoodnetwork.net
 host_id: us-prod
 rails_env: production
 

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -109,7 +109,7 @@ uk-staging2
 openfoodnetwork.net ansible_host=52.3.171.208
 
 [us-migrate]
-migrate.openfoodnetwork.net ansible_host=161.35.232.244
+migration.openfoodnetwork.net ansible_host=161.35.232.244
 
 [us:children]
 us-prod


### PR DESCRIPTION
This might not even need to be merged? More just an FYI to anyone in the future or who might be working on the migration. Because I ran the `provision.yml` script more than five times I got rate limited by LetsEncrypt so I had to change the subdomain. 