### PR TITLE
Asset transfer update

### DIFF
--- a/roles/migrate_assets/defaults/main.yml
+++ b/roles/migrate_assets/defaults/main.yml
@@ -6,5 +6,6 @@ local_asset_path: "../backups"
 
 migrate_dirs:
   - images
+  - files
   - spree
   - system

--- a/roles/migrate_assets/defaults/main.yml
+++ b/roles/migrate_assets/defaults/main.yml
@@ -5,7 +5,6 @@ dest_path: "{{ shared_path }}"
 local_asset_path: "../backups"
 
 migrate_dirs:
-  - assets
   - images
   - spree
   - system


### PR DESCRIPTION
Updates the `transfer_assets` playbook to bring it in line with asset changes made since the last server migration.

- `/assets` path is removed. We excluded this from being persisted between deployments, it should only contain precompiled assets which will be generated during deployments, so it doesn't need to be transferred when migrating servers.
- `/files` path is added. This directory now contains uploaded T&C PDFs, and we need to transfer them when migrating a server.

Tested and working :heavy_check_mark: 