### PR TITLE
US migration configs

### DIFF
--- a/inventory/host_vars/migration.openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/migration.openfoodnetwork.net/config.yml
@@ -1,6 +1,6 @@
 ---
 
-domain: migration.openfoodnetwork.net
+domain: openfoodnetwork.net
 host_id: us-prod
 rails_env: production
 
@@ -10,11 +10,10 @@ mail_domain: openfoodnetwork.net
 
 # Optional list of subdomains to register in letsencrypt certificate
 # Defaults to {{ domain }} if list is undefined
-#
-#certbot_domains:
-#  - example.com
-#  - www.example.com
-#  - info.example.com
+
+certbot_domains:
+  - openfoodnetwork.net
+  - migration.openfoodnetwork.net
 
 # Size in bytes. You can also use units like 1G, 512MiB or 1000KB. See: `man fallocate`
 # The default is `false`, not installing a swapfile.


### PR DESCRIPTION
Quick update to the temporary configs for the US server migration...

These changes are live now on the `us-migrate` server (certificates recreated)