### PR TITLE
Update wal_sender_timeout

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -99,6 +99,8 @@ postgresql_global_config_options:
     value: "{{ postgres_listen_addresses | join(',') }}"
   - option: shared_preload_libraries
     value: "{{ postgres_shared_preload_libraries | join(',') }}"
+  - option: wal_sender_timeout
+    value: "300000"
   - option: include_dir
     value: "conf.d"
 


### PR DESCRIPTION
Metabase related. Apparently long-running transactions can cause the Postgres replication slot to shut down. This can happen in cases like large data migrations.

Note: the value is set in milliseconds (5 minutes).