### PR TITLE
Fix beta_testers configs

### DIFF
--- a/inventory/host_vars/www.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/www.coopcircuits.fr/config.yml
@@ -27,4 +27,5 @@ enable_rails_apm: "true" # has to be explicitly defined as a string due to some 
 attachment_path: "home/openfoodnetwork/apps/openfoodnetwork/current/public/spree/products/:id/:style/:basename.:extension"
 attachment_url: ofn-prod.s3.us-east-1.amazonaws.com
 
-beta_testers: all
+beta_testers:
+  - all

--- a/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/www.openfoodnetwork.org.uk/config.yml
@@ -22,4 +22,5 @@ enable_rails_apm: "true" # has to be explicitly defined as a string due to some 
 
 attachment_url: ofn-uk-production.s3.us-east-1.amazonaws.com
 
-beta_testers: all
+beta_testers:
+  - all


### PR DESCRIPTION
The output being written to `application.yml` was:
```
BETA_TESTERS: a,l,l
```
due to the way the list items are split in the template file.