### PR TITLE
Use new FR_staging ip in hosts file

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -140,7 +140,7 @@ es-staging
 www.coopcircuits.fr ansible_host=51.68.226.206
 
 [fr-staging]
-staging.coopcircuits.fr ansible_host=149.202.55.45
+staging.coopcircuits.fr ansible_host=51.178.24.33
 
 [fr:children]
 fr-prod


### PR DESCRIPTION
FR_staging server is back in shape, https://staging.coopcircuits.fr, I have created this PR to update the new IP.

fyi, I tried to deploy it with ansible recipes under Ubuntu 20.04 but it fails due to Ubuntu changing 'python-apt' package which is required into 'geerlingguy.security'. Then I put it to Ubuntu 18.04 where the only issue I faced was related to GD library dependency for Nginx which was fixed installing manually 'libgd-dev' package.