### PR TITLE
Add environment variables for Discourse SSO and alternate geocoder services to servers if present

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -83,3 +83,8 @@ smtp_password:
 #
 #db_integrations:
 #  - { user: datadog, state: present, password: "{{ datadog_db_password }}" }
+
+# For using a geocoding service other than Google you will need:
+#geocoder_api_key: pk.xxxx
+#geocoder_service: mapbox
+#geocoder_timeout: 7

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -59,6 +59,16 @@ BUGSNAG_API_KEY: {{ bugsnag_key }}
 BUGSNAG_JS_KEY: {{ bugsnag_js_key }}
 {% endif %}
 
+{% if geocoder_api_key is defined %}
+GEOCODER_API_KEY: {{ geocoder_api_key }}
+{% endif %}
+{% if geocoder_service is defined %}
+GEOCODER_SERVICE: {{ geocoder_service }}
+{% endif %}
+{% if geocoder_timeout is defined %}
+GEOCODER_TIMEOUT: {{ geocoder_timeout }}
+{% endif %}
+
 {{ custom_application_env_vars | default('') }}
 
 {% if beta_testers is defined %}


### PR DESCRIPTION
If instances want a SSO integration with Discourse or to use [alternate geocoder services](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/config/initializers/geocoder.rb) we could add these environment variables to servers. Although maybe it's ok for those variables to be just added via `custom_application_env_vars`, feel free to close this if so.