### PR TITLE
Provision Redis

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -5,3 +5,9 @@
     name: memcached
     state: restarted
   become: yes
+
+- name: restart redis
+  service:
+    name: redis-server
+    state: restarted
+  become: yes

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -52,3 +52,6 @@
   become: yes
   notify:
     - restart memcached
+
+- name: set up redis
+  include_tasks: redis.yml

--- a/roles/common/tasks/redis.yml
+++ b/roles/common/tasks/redis.yml
@@ -1,0 +1,34 @@
+---
+
+- name: add official redis ppa
+  apt_repository:
+    repo: ppa:redislabs/redis
+  become: yes
+
+- name: install redis-server
+  apt:
+    name: redis-server
+    update_cache: yes
+  become: yes
+
+- name: enable custom config file
+  lineinfile:
+    name: "/etc/redis/redis.conf"
+    line: "include /etc/redis/local.conf"
+    state: present
+  become: yes
+
+- name: add redis configuration
+  template:
+    src: redis.conf.j2
+    dest: /etc/redis/local.conf
+    mode: 0644
+  become: yes
+  notify:
+    - restart redis
+
+- name: ensure service is enabled
+  service:
+    name: redis-server
+    enabled: yes
+  become: yes

--- a/roles/common/templates/redis.conf.j2
+++ b/roles/common/templates/redis.conf.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+
+maxmemory 124mb
+maxmemory-policy volatile-lru

--- a/roles/deploy/tasks/check_redis.yml
+++ b/roles/deploy/tasks/check_redis.yml
@@ -14,5 +14,11 @@
   check_mode: yes # Don't actually modify the file
   become: yes
   register: redis_requirement
-  when: "'redis-service' not in services"
-  failed_when: redis_requirement is failed
+  ignore_errors: true
+
+- name: stop deployment if redis is both required and absent
+  fail:
+    msg: |
+      The deployed OFN version requires Redis to be installed.
+      Please provision with the latest copy of ofn-install before deploying.
+  when: "redis_requirement is changed and 'redis-server.service' not in services"

--- a/roles/deploy/tasks/check_redis.yml
+++ b/roles/deploy/tasks/check_redis.yml
@@ -1,0 +1,18 @@
+---
+
+# This check fails if Redis is present in the new build's Gemfile but Redis is not installed yet,
+# which will block the deployment from proceeding (until the server is correctly provisioned).
+
+- name: gather host services facts
+  service_facts:
+
+- name: check redis presence in gemfile
+  lineinfile:
+    dest: "{{ build_path }}/Gemfile"
+    regex: "^gem .*redis"
+    state: absent
+  check_mode: yes # Don't actually modify the file
+  become: yes
+  register: redis_requirement
+  when: "'redis-service' not in services"
+  failed_when: redis_requirement is failed

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -11,6 +11,9 @@
     force: yes
   tags: clone
 
+- name: check redis required/present
+  include_tasks: check_redis.yml
+
 - name: symlink custom assets into the build
   file:
     src: "{{ item.src }}"

--- a/roles/webserver/templates/delayed_job.service.j2
+++ b/roles/webserver/templates/delayed_job.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Open Food Network delayed_job
-After=memcached.service postgresql.service
+After=postgresql.service
 
 [Service]
 Type=forking

--- a/roles/webserver/templates/unicorn.rb.j2
+++ b/roles/webserver/templates/unicorn.rb.j2
@@ -45,7 +45,9 @@ if ['production', 'staging'].include? ENV["RAILS_ENV"]
   end
 
   after_fork do |server, worker|
-    defined?(ActiveRecord::Base) and
-        ActiveRecord::Base.establish_connection
+    defined?(ActiveRecord::Base) && ActiveRecord::Base.establish_connection
+
+    # Ensure forked workers are not sharing a single Redis connection with master process
+    defined?(Redis) && Redis.current.disconnect!
   end
 end

--- a/roles/webserver/templates/unicorn.service.j2
+++ b/roles/webserver/templates/unicorn.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Open Food Network unicorn server
-After=memcached.service postgresql.service
+After=postgresql.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Part of https://github.com/openfoodfoundation/openfoodnetwork/issues/7541

- Installs and configures Redis
- Does _not_ remove Memcached (we can do that later, and we need to maintain some backwards-compatibility during the transition period until all servers are updated) :ok_hand: 
- Adds a failsafe check in `deploy.yml` to stop deployment if Redis is in the Gemfile but has not been installed yet (for instances not managed by the core team, so we don't break anything in production) :heart: 
