### PR TITLE
Pass configs needed for mail to the app

### DIFF
--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -61,6 +61,24 @@ BUGSNAG_JS_KEY: {{ bugsnag_js_key }}
 
 SITE_URL: {{ domain }}
 
+MAIL_DOMAIN: {{ mail_domain }}
+MAIL_HOST: {{ mail_host }}
+MAIL_PORT: {{ mail_port }}
+{% if mail_secure_connection is defined %}
+MAIL_SECURE_CONNECTION: {{ mail_secure_connection  }}
+{% endif %}
+{% if mail_auth_type is defined %}
+MAIL_AUTH_TYPE: {{ mail_auth_type }}
+{% endif %}
+SMTP_USERNAME: {{ smtp_username }}
+SMTP_PASSWORD: {{ smtp_password }}
+{% if mails_from is defined %}
+MAILS_FROM: {{ mails_from }}
+{% endif %}
+{% if mail_bcc is defined %}
+MAIL_BCC: {{ mail_bcc }}
+{% endif %}
+
 {% if geocoder_api_key is defined %}
 GEOCODER_API_KEY: {{ geocoder_api_key }}
 {% endif %}

--- a/roles/app/templates/application.yml.j2
+++ b/roles/app/templates/application.yml.j2
@@ -59,6 +59,8 @@ BUGSNAG_API_KEY: {{ bugsnag_key }}
 BUGSNAG_JS_KEY: {{ bugsnag_js_key }}
 {% endif %}
 
+SITE_URL: {{ domain }}
+
 {% if geocoder_api_key is defined %}
 GEOCODER_API_KEY: {{ geocoder_api_key }}
 {% endif %}

--- a/roles/unicorn_user/templates/defaults.j2
+++ b/roles/unicorn_user/templates/defaults.j2
@@ -1,23 +1,5 @@
 RAILS_ENV={{ rails_env }}
 
-MAIL_DOMAIN={{ mail_domain }}
-MAIL_HOST={{ mail_host }}
-MAIL_PORT={{ mail_port }}
-{% if mail_secure_connection is defined %}
-  MAIL_SECURE_CONNECTION={{ mail_secure_connection  }}
-{% endif %}
-{% if mail_auth_type is defined %}
-  MAIL_AUTH_TYPE={{ mail_auth_type }}
-{% endif %}
-SMTP_USERNAME={{ smtp_username }}
-SMTP_PASSWORD={{ smtp_password }}
-{% if mails_from is defined %}
-  MAILS_FROM={{ mails_from }}
-{% endif %}
-{% if mail_bcc is defined %}
-  MAIL_BCC={{ mail_bcc }}
-{% endif %}
-
 {% if db_user is defined %}
 OFN_DB_USERNAME={{ db_user }}
 {% endif %}


### PR DESCRIPTION
Sets up: https://github.com/openfoodfoundation/openfoodnetwork/pull/7673

Updates the way mail-related configs are passed to the app. Previously we were setting them in the environment of the unicorn user, but now we pass them to the app itself.

When testing this I also noticed there are some cases where unicorn is restarted where the ENV vars for the unicorn user are not actually passed to Rails, possibly due to the service being restarted as root (sudo)? :warning: (that's fixed now)