### PR TITLE
Remove libssl1.0-dev dependency

### DIFF
--- a/roles/compatibility/tasks/main.yml
+++ b/roles/compatibility/tasks/main.yml
@@ -17,9 +17,3 @@
     bionic_packages:
       - software-properties-common
   when: ansible_distribution_major_version == '18'
-
-- name: define additional rbenv build dependencies for Ruby 2.1.5 on Ubuntu 18
-  set_fact:
-    rbenv_extra_depends:
-      - libssl1.0-dev
-  when: ansible_distribution_major_version == '18'


### PR DESCRIPTION
This outdated SSL package is no longer required to build Ruby on modern systems since Ruby 2.4.x

:tada:

Also frees up the rebenv role's `rbenv_extra_depends` variable to be used for more useful things, like installing `jemalloc`...