### PR TITLE
Don't use jemalloc in Travis

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -55,11 +55,13 @@ ruby_version: 2.5.9
 rbenv_extra_depends:
   - libjemalloc-dev
 
+ruby_compile_options: "--with-jemalloc"
+
 ruby_versions:
   - version: 2.5.8
   - version: 2.5.9
     env:
-      RUBY_CONFIGURE_OPTS: "--with-jemalloc"
+      RUBY_CONFIGURE_OPTS: "{{ ruby_compile_options }}"
 
 env:
   RAILS_ENV: "{{ rails_env }}"

--- a/inventory/host_vars/local_travis/config.yml
+++ b/inventory/host_vars/local_travis/config.yml
@@ -19,3 +19,6 @@ mail_host: 'example.com'
 mail_port: 25
 smtp_username: 'admin'
 smtp_password: 'password'
+
+rbenv_extra_depends: []
+ruby_compile_options: ""


### PR DESCRIPTION
The Travis build environment is really flaky, and it apparently doesn't like `jemalloc`.

This avoids using it in Travis when testing our playbooks.