### PR TITLE
Don't start Sidekiq in Travis

### DIFF
--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -24,6 +24,7 @@
   when:
    - "'sidekiq.service' in services"
    - sidekiq_requirement.changed
+   - inventory_hostname != 'local_travis'
   listen: update jobs queue
 
 - name: restart delayed_job unless using sidekiq


### PR DESCRIPTION
The Travis build environment doesn't like running Sidekiq via a service, so we can skip it here. We don't really test Sidekiq or jobs processing in any of our playbook tests here anyway, so it's not a huge loss. This should get the ofn-install build back to green (it's currently red).

Side note: this is the third annoying issue that's come up recently relating to the Travis build environment, it would be good to try switching to Github CI for running the ofn-install build at some point...