### PR TITLE
Ignore delayed_job errors if the service has been removed

### DIFF
--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -32,6 +32,7 @@
     state: restarted
   become: yes
   become_user: root
+  ignore_errors: yes
   when:
    - "'delayed_job_openfoodnetwork.service' in services and services['delayed_job_openfoodnetwork.service']['status'] == 'enabled'"
    - not sidekiq_requirement.changed


### PR DESCRIPTION
Another step in phasing out `delayed_job`. Ignores errors if the service isn't found.