### PR TITLE
Remove --production flag from yarn install step

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -76,7 +76,6 @@
   yarn:
     path: "{{ build_path }}"
     executable: "{{ npm_prefix }}/bin/yarn"
-    production: yes
   become: true
   become_user: "{{ unicorn_user }}"
 


### PR DESCRIPTION
WIP

Apparently this flag can cause issues and is not recommended.