### PR TITLE
Add Open ID ENV variables if defined

### DIFF
--- a/roles/app/templates/env.j2
+++ b/roles/app/templates/env.j2
@@ -83,6 +83,16 @@ GEOCODER_SERVICE="{{ geocoder_service }}"
 GEOCODER_TIMEOUT="{{ geocoder_timeout }}"
 {% endif %}
 
+{% if openid_app_id is defined %}
+OPENID_APP_ID="{{ openid_app_id }}"
+{% endif %}
+{% if openid_app_secret is defined %}
+OPENID_APP_SECRET="{{ openid_app_secret }}"
+{% endif %}
+{% if openid_redirect_uri is defined %}
+OPENID_REDIRECT_URI="{{ openid_redirect_uri }}"
+{% endif %}
+
 {{ custom_env_vars | default('') }}"
 
 {% if beta_testers is defined %}


### PR DESCRIPTION
This will take the following settings if defined in secrets and include them as ENV variables:

```
openid_app_id
openid_app_secret
openid_redirect_uri
```

These settings will be used in https://github.com/openfoodfoundation/openfoodnetwork/pull/7880 to configure an instance's Open ID Connect integration. This is being added as part of the work on the DFC API.

Specifically they'll be used in the devise initializer:
https://github.com/openfoodfoundation/openfoodnetwork/blob/35869e1be812d03385b565fe3c99c3f47b109601/config/initializers/devise.rb#L150-L152
