### PR TITLE
Cache the rbenv directory in the ofn-install build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,5 +38,15 @@ jobs:
           pip install -r requirements.txt
           bin/setup
 
+      - name: Cache Ruby binary compiling
+        id: cache-ruby
+        uses: actions/cache@v2
+        with:
+          path: ~/.rbenv
+          key: ${{ runner.os }}-ruby-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ruby-
+            ${{ runner.os }}-
+
       - name: Test Playbooks
         run: ansible-playbook tests/suite.yml --limit test --connection local


### PR DESCRIPTION
This should avoid downloading and compiling the Ruby source code in every build, cutting the build time dramatically.