### PR TITLE
Update Semaphore deployment script

### DIFF
--- a/roles/semaphore_deployment/templates/deploy.j2
+++ b/roles/semaphore_deployment/templates/deploy.j2
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 set -e
-branch="$1"
+IFS=' ' read -ra git_args <<< "$1"
+branch=${git_args[0]}
+commit=${git_args[1]}
 allowed=^[a-zA-Z0-9._/\-]+$
 
 # Given branch name must be a single string with no spaces,
@@ -9,8 +11,20 @@ allowed=^[a-zA-Z0-9._/\-]+$
 
 if [[ ! $branch =~ $allowed ]]
 then
-  echo "Invalid branch name given." >&2
+  echo "Invalid branch name given: $branch" >&2
   exit 1
+fi
+
+# If we're deploying `master` it's usually because we are checking a release or a certain version,
+# so we want the exact commit to be deployed. Otherwise, we're testing a pull request, so we
+# want to use the PR's branch (which includes a merge with master).
+if [ $branch = "master" ]
+then
+  deploy=$commit
+  echo "Deploying master, commit: $commit"
+else
+  deploy=$branch
+  echo "Deploying $branch"
 fi
 
 cd "/home/{{ deployment_user }}/ofn-install"
@@ -19,4 +33,4 @@ cd "/home/{{ deployment_user }}/ofn-install"
 git pull
 
 # Deploy
-ansible-playbook playbooks/deploy.yml --limit {{ ansible_limit }} --connection local -e "git_repo=https://github.com/openfoodfoundation/openfoodnetwork.git git_version=$branch"
+ansible-playbook playbooks/deploy.yml --limit {{ ansible_limit }} --connection local -e "git_repo=https://github.com/openfoodfoundation/openfoodnetwork.git git_version=$deploy"

--- a/roles/semaphore_deployment/templates/deploy.j2
+++ b/roles/semaphore_deployment/templates/deploy.j2
@@ -9,9 +9,9 @@ allowed=^[a-zA-Z0-9._/\-]+$
 # Given branch name must be a single string with no spaces,
 # containing only: ".", "-", "/", "_", or alphanumeric characters.
 
-if [[ ! $branch =~ $allowed ]]
+if [[ ! $branch =~ $allowed || ! $commit =~ $allowed ]]
 then
-  echo "Invalid branch name given: $branch" >&2
+  echo "Invalid branch name or commit ref given." >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes https://github.com/openfoodfoundation/openfoodnetwork/issues/7986

When deploying to staging via Semaphore, specific versions of master (including releases) will use the exact commit, but pull requests will use the latest version of the branch merged with master. This means we'll get accurate release versions staged, but we'll also include recent changes when testing PRs that haven't been rebased recently.