### PR TITLE
Exclude development and test gems in staging

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -61,7 +61,7 @@
   command: >
     bash -lc "bundle install
     --gemfile {{ build_path }}/Gemfile --path /home/{{ unicorn_user }}/.gem
-    --deployment {{ '--without development test' if rails_env == 'production' else '' }}"
+    --deployment {{ '--without development test' if rails_env != 'development' else '' }}"
   environment:
     LANG: "{{ language }}"
     LC_ALL: "{{ language }}"


### PR DESCRIPTION
We currently install dev and test gems when deploying to staging. This means we currently end up with Rails running through Spring servers in staging, which is a really bad idea...