### PR TITLE
Puma taming

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -371,10 +371,7 @@ nginx_events_params:
 
 nginx_configs:
   upstream:
-    - upstream rails {
-        server unix:{{ puma_sock }} fail_timeout=0;
-        server unix:{{ unicorn_sock }} fail_timeout=0;
-      }
+    - upstream rails { server unix:{{ puma_sock }} fail_timeout=0; }
 
 # Use python2.7 interpeter
 ansible_python_interpreter: '/usr/bin/python2.7'

--- a/roles/webserver/templates/puma.service.j2
+++ b/roles/webserver/templates/puma.service.j2
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=notify
-WatchdogSec=10
+WatchdogSec=30
 User={{ app_user }}
 
 WorkingDirectory={{ current_path }}
@@ -18,8 +18,9 @@ ExecStart=/bin/bash -lc "bundle exec --keep-file-descriptors puma -C {{ shared_p
 ExecReload=/bin/bash -lc "bundle exec pumactl phased-restart -S {{ shared_path }}/pids/puma.state"
 
 SyslogIdentifier=puma
-Restart=always
-RestartSec=5s
+Restart=on-failure
+RestartSec=30s
+TimeoutSec=30s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Removes a temporary nginx config used for transitioning from unicorn to puma
- Loosens the restart timers in the puma systemd service so they're not as aggressive. This potentially led to some deployment issues, but I didn't manage to replicate the problem directly. The new settings are in line with the old ones we used with unicorn.