### PR TITLE
Remove oidc redirect_uri from env var check

### DIFF
--- a/roles/app/templates/env.j2
+++ b/roles/app/templates/env.j2
@@ -92,9 +92,6 @@ OPENID_APP_ID="{{ openid_app_id }}"
 {% if openid_app_secret is defined %}
 OPENID_APP_SECRET="{{ openid_app_secret }}"
 {% endif %}
-{% if openid_redirect_uri is defined %}
-OPENID_REDIRECT_URI="{{ openid_redirect_uri }}"
-{% endif %}
 
 {{ custom_env_vars | default('') }}
 


### PR DESCRIPTION
This value is not a secret, we put it directly into the Devise configuration here, https://github.com/openfoodfoundation/openfoodnetwork/pull/7880/files#diff-cb6e8126296dbc007e7625eee863de5c3213ed949b9999ea3418775f65826531R158