### PR TITLE
Allow rollback playbook to target a specific release

### DIFF
--- a/roles/rollback/defaults/main.yml
+++ b/roles/rollback/defaults/main.yml
@@ -1,0 +1,9 @@
+
+rollback_default_path: "{{ rollback_symlink.stat.lnk_source }}"
+rollback_default_sql_path: "{{ rollback_sql_path }}"
+
+rollback_target_path: "{{ releases_path }}/{{ release_timestamp }}"
+rollback_target_sql_path: "{{ releases_path }}/{{ release_timestamp }}.sql.gz"
+
+rollback_calculated_path: "{{ rollback_target_path if rollback_timestamp is defined else rollback_default_path }}"
+rollback_calculated_sql_path: "{{ rollback_target_sql_path if rollback_timestamp is defined else rollback_default_sql_path }}"

--- a/roles/rollback/tasks/main.yml
+++ b/roles/rollback/tasks/main.yml
@@ -1,13 +1,22 @@
 --- # Rollback
 
+# Note: this is a serious operation which resets both the code and the *database* to a previous point
+# in time. It should never be run against a production server unless it's an *extreme* emergency.
+#
+# By default this playbook will roll back to the previous deployed release. If you want to roll back
+# to a specific target in the releases path instead, set the `release_timestamp` variable, eg:
+#
+# ansible-playbook playbooks/rollback.yml --limit uk-staging -e "release_timestamp=2021-09-17-134100"
+
 - name: fetch stats of rollback symlink
   stat:
     path: "{{ rollback_path }}"
   register: rollback_symlink
+  when: release_target is not defined
 
 - name: symlink rollback source to current path
   file:
-    src: "{{ rollback_symlink.stat.lnk_source }}"
+    src: "{{ rollback_calculated_path }}"
     dest: "{{ current_path }}"
     owner: "{{ app_user }}"
     state: link
@@ -21,4 +30,4 @@
     name: db_restore
     tasks_from: restore_database
   vars:
-    database_dump_path: "{{ rollback_sql_path }}"
+    database_dump_path: "{{ rollback_calculated_sql_path }}"


### PR DESCRIPTION
Allows the `rollback` playbook to optionally target a specific release (eg `2021-09-17-134844`) instead of just the last release. 