### PR TITLE
Drop watchdog in favour of simpler process monitoring

### DIFF
--- a/roles/webserver/templates/puma.service.j2
+++ b/roles/webserver/templates/puma.service.j2
@@ -3,8 +3,7 @@ Description=Puma HTTP Server
 After=network.target
 
 [Service]
-Type=notify
-WatchdogSec=30
+Type=simple
 User={{ app_user }}
 
 WorkingDirectory={{ current_path }}


### PR DESCRIPTION
After investigating our recent Puma restart issues I have a strong suspicion it's related to use of the watchdog setting in `systemd`, but it's really difficult to replicate.

I think there's something going on between `rbenv` and `systemd`, where the "watchdog" either isn't correctly checking the correct process ID after forking, or there's a timeout that triggers _another_ restart before the previous one has finished at the end of deployment.

If my hunch is right, this change will fix the issue. If it's not, it won't do any harm.