### PR TITLE
Add updated TLS cipher suite configuration

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -272,6 +272,13 @@ nginx_acme_challenge_config: |+
 
 nginx_valid_methods: limit_except GET POST PUT PATCH DELETE OPTIONS { deny all; }
 
+# Cipher suite selection based on these settings (with TLSv1 and TLSv1.1 removed):
+# https://ssl-config.mozilla.org/#server=nginx&version=1.16.1&config=old&openssl=1.0.2g
+nginx_tls_cipher_suites: |+
+  ssl_protocols TLSv1.2;
+  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA;
+  ssl_prefer_server_ciphers on;
+
 nginx_sites:
   default:
     - |
@@ -312,6 +319,8 @@ nginx_sites:
 
       ssl_certificate      /etc/letsencrypt/live/{{ certbot_cert_name | default(domain) }}/fullchain.pem;
       ssl_certificate_key  /etc/letsencrypt/live/{{ certbot_cert_name | default(domain) }}/privkey.pem;
+
+      {{ nginx_tls_cipher_suites }}
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;


### PR DESCRIPTION
Adds some TLS hardening and ensures ciphers blacklisted under the HTTPS2 spec don't get mistakenly used when connections are upgraded from HTTPS1 on the fly.

Should resolve some recent reports on certain Mac OSX / Safari versions resulting in `ERR_HTTP2_INADEQUATE_TRANSPORT_SECURITY` errors with HTTPS.

Also boosts our TLS analysis rating on www.ssllabs.com from a **B** to an **A+** :ok_hand: 