### PR TITLE
Avoid truncation of sidekiq log

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -181,7 +181,8 @@ logrotate_applications:
   - name: rails
     definitions:
       - logs:
-          - "{{ current_path }}/log/*.log"
+          - "{{ current_path }}/log/production.log"
+          - "{{ current_path }}/log/staging.log"
         options:
           - weekly        # rotate weekly
           - rotate 4      # delete logs older than 4 rotations
@@ -189,6 +190,19 @@ logrotate_applications:
           - missingok     # ignore missing logs
           - notifempty    # don't rotate if empty
           - copytruncate  # copy the log, then empty the active logfile
+
+  - name: sidekiq
+    definitions:
+      - logs:
+          - "{{ current_path }}/log/sidekiq.log"
+        options:
+          - daily
+          - rotate 14     # delete logs older than 14 days
+          - compress      # compress rotated logs
+          - missingok     # ignore missing logs
+          - notifempty    # don't rotate if empty
+        postrotate:
+          - "pkill -USR2 -f sidekiq"
 
   - name: postgres_queries
     definitions:


### PR DESCRIPTION
Each log file has to be rotated explicitly now. That makes sure that we apply rotation rules suited for each file.

But I would also be happy to go another path and log sidekiq via systemd. I guess that we would just need to remove the redirection from the service:
https://github.com/openfoodfoundation/ofn-install/blob/59888d0078b4a4a28b4983ec54355e6238d3d1e7/roles/sidekiq/templates/sidekiq.service.j2#L14-L16

**WIP:** the first commit belongs to another PR but I wanted to avoid conflicts.