### PR TITLE
Rotate puma.log to save disk space

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -184,6 +184,7 @@ logrotate_applications:
       - logs:
           - "{{ current_path }}/log/production.log"
           - "{{ current_path }}/log/staging.log"
+          - "{{ log_path }}/puma.log"
         options:
           - weekly        # rotate weekly
           - rotate 4      # delete logs older than 4 rotations


### PR DESCRIPTION
Australian production used over 90% of its disk. I provisioned this already. :heavy_check_mark: 

Closes #806.