### PR TITLE
Add support to Ubuntu 20.04

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -21,7 +21,7 @@
   version: 3.1.0
 
 - src: geerlingguy.postgresql
-  version: 1.4.5
+  version: 3.3.0
 
 - src: libre_ops.wal2json
   version: 1.0.5

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -98,7 +98,7 @@ postgres_encoding: en_US.utf8
 # Entries marked custom_* can be defined in /host_vars files, and will be appended
 # to the defaults if present. Make sure you use the "list" notation with the dashes!
 
-postgresql_version: "{% if ansible_distribution_major_version == '16' %}9.5{% else %}10{% endif %}"
+postgresql_version: "{% if ansible_distribution_major_version == '16' %}9.5{% elif ansible_distribution_major_version == '18' %}10{% else %}12{% endif %}"
 postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
 postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
 postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -395,8 +395,8 @@ nginx_configs:
   upstream:
     - upstream rails { server unix:{{ puma_sock }} fail_timeout=0; }
 
-# Use python2.7 interpeter
-ansible_python_interpreter: '/usr/bin/python2.7'
+# Set python interpeter to the symlink created by setup
+ansible_python_interpreter: '/usr/bin/python'
 
 # Fix for renamed branch in rbenv-install repo
 rbenv_plugins:

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -115,6 +115,12 @@
       tags: logrotate
 
   tasks:
+    - name: Fix Ruby # noqa 301
+      command: bash -lc "rbenv uninstall -f {{ ruby_version }} && rbenv install {{ ruby_version }}"
+      become: yes
+      become_user: "{{ app_user }}"
+      when: ansible_distribution_major_version >= '20'
+
     - meta: flush_handlers # Ensure handlers run successfully before reporting success
 
     - name: notify slack

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -116,7 +116,9 @@
 
   tasks:
     - name: Fix Ruby # noqa 301
-      command: bash -lc "rbenv uninstall -f {{ ruby_version }} && rbenv install {{ ruby_version }}"
+      command:
+        cmd: bash -lc "rbenv uninstall -f {{ ruby_version }} && rbenv install {{ ruby_version }} && touch ~/.rbenv/versions/{{ ruby_version }}/.reinstalled"
+        creates: "~/.rbenv/versions/{{ ruby_version }}/.reinstalled"
       become: yes
       become_user: "{{ app_user }}"
       when: ansible_distribution_major_version >= '20'

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -11,9 +11,9 @@
   gather_facts: no
   remote_user: root
   tasks:
-    - name: Install python 2.7
+    - name: Install python
       become: yes
-      raw: apt-get update -qq && apt-get install -qq python2.7
+      raw: test $(lsb_release -sr | cut -d . -f1) -lt 20 && (apt-get update -qq && apt-get install -qq python2.7 && ln -s /usr/bin/python2.7 /usr/bin/python) || (apt-get update -qq && apt-get install -qq python3 && ln -s /usr/bin/python3 /usr/bin/python)
       tags: skip_ansible_lint
 
 # Add the default user and ssh keys as root

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -15,7 +15,6 @@
     packages:
       # Ansible support
       - python-pycurl
-      - python-psycopg2
       - python3-psycopg2
 
       # unknown why or if needed
@@ -43,6 +42,17 @@
       - libxrender1
       - webp
   tags: packages
+
+- name: install base packages for old distros
+  apt:
+    name: "{{ packages }}"
+  become: yes
+  vars:
+    packages:
+      # Ansible support
+      - python-psycopg2
+  tags: packages
+  when: ansible_distribution_major_version <= '18'
 
 - name: set up redis
   include_tasks: redis.yml

--- a/roles/compatibility/tasks/main.yml
+++ b/roles/compatibility/tasks/main.yml
@@ -16,4 +16,4 @@
   vars:
     bionic_packages:
       - software-properties-common
-  when: ansible_distribution_major_version == '18'
+  when: ansible_distribution_major_version >= '18'


### PR DESCRIPTION
I did my best to create atomic commits with messages full of details.

This should close issue https://github.com/openfoodfoundation/ofn-install/issues/811

I have developed using Vagrant by changing the the image to focal64. Then I ran:

`vagrant destroy -f && vagrant up && ansible-playbook --limit vagrant playbooks/setup.yml && ansible-playbook --limit vagrant playbooks/provision.yml && ansible-playbook --limit vagrant playbooks/deploy.yml`

After I got all these commands to run without errors I check in the browser if http://localhost:8080 loaded OFN homepage without errors.

With everything working in 20.04 I got back the Vagrantfile to xenial and bionic, repeating the test detailed above, in order to check if my changes had no unwanted side effects in them. All looked good in my tests.

Final notes:

* the community should consider to EOL Ubuntu 16 soon which will make possible to remove many of the conditionals in the infrastructure automation we have here
* this PR is a step towards getting https://github.com/openfoodfoundation/ofn-install/issues/765 done
* this PR should replace https://github.com/openfoodfoundation/ofn-install/pull/659