### PR TITLE
Support webp images

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -41,6 +41,7 @@
       - libxml2-dev
       - libxslt1-dev
       - libxrender1
+      - webp
   tags: packages
 
 - name: set up redis


### PR DESCRIPTION
Uploaded product images are transformed into different sizes but we were missing the webp tools to transform .webp images. This is now added.

### Testing steps

If you want to reproduce the bug:

- Choose a staging server other then au-staging because I installed webp there already.
- Go to /admin/products.
- Upload a webp file.

Testing this pull request:

- Have SSH access to the staging server and ofn-install set up with Ansible.
- Check out this pull request and run:
- `ansible-playbook -l fr-staging -t packages playbooks/provision.yml` or uk-staging.
- Then go to /admin/products.
- Upload a webp file.

### After merge

```
ansible-playbook -l all-staging -t packages playbooks/provision.yml
ansible-playbook -l all-prod -t packages playbooks/provision.yml
```