### PR TITLE
Remove wal2json from provisioning

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -23,9 +23,6 @@
 - src: geerlingguy.postgresql
   version: 3.3.0
 
-- src: libre_ops.wal2json
-  version: 1.0.5
-
 - src: libre_ops.multi_redis
   version: 1.0.1
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -125,7 +125,6 @@ postgres_listen_addresses:
 
 postgres_shared_preload_libraries:
   - pg_stat_statements
-  - wal2json
 
 postgresql_global_config_options:
   - option: listen_addresses

--- a/roles/dbserver/tasks/main.yml
+++ b/roles/dbserver/tasks/main.yml
@@ -34,9 +34,3 @@
 
 - import_tasks: fix_template_encoding.yml
   tags: template_encoding
-
-- name: install wal2json module
-  include_role:
-    name: libre_ops.wal2json
-  vars:
-    wal2json_set_preload_libraries: false


### PR DESCRIPTION
It was failing due to an outdated repository. And it was used for Metabase which is currently broken and that approach has been abandoned.