### PR TITLE
Remove old SSH admin keys

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -240,7 +240,11 @@ core_devs:
   - filipe
   - jb
   - david
+
+retired_core_devs:
   - george
+  - pau
+  - stveep
 
 #----------------------------------------------------------------------
 # nginx config

--- a/roles/app_user/tasks/main.yml
+++ b/roles/app_user/tasks/main.yml
@@ -28,6 +28,13 @@
   become: yes
   when: ssh_key_path is defined
 
+- name: remove old ssh keys from app user
+  authorized_key:
+    user: "{{ app_user }}"
+    key: "{{ lookup('file', inventory_dir + '/../files/keys/' + item + '.pub') }}"
+    state: absent
+  with_flattened: "{{ retired_core_devs }}"
+
 - name: Write OFN environment variables defaults
   become: true
   template:

--- a/roles/ssh_keys/tasks/main.yml
+++ b/roles/ssh_keys/tasks/main.yml
@@ -1,9 +1,9 @@
 --- # Provision ssh keys
 - name: add ssh keys users_sysadmin
   authorized_key:
-    user={{ user }}
-    key="{{ lookup('file', inventory_dir + '/../files/keys/' + item + '.pub') }}"
-    state=present
+    user: "{{ user }}"
+    key: "{{ lookup('file', inventory_dir + '/../files/keys/' + item + '.pub') }}"
+    state: present
   with_flattened: "{{ users_sysadmin }}"
   when: ssh_key_path is undefined
 
@@ -15,3 +15,10 @@
     key: "{{ lookup('file', ssh_key_path) }}"
     state: present
   when: ssh_key_path is defined
+
+- name: remove old ssh keys from ofn-admin
+  authorized_key:
+    user: "{{ user }}"
+    key: "{{ lookup('file', inventory_dir + '/../files/keys/' + item + '.pub') }}"
+    state: absent
+  with_flattened: "{{ retired_core_devs }}"


### PR DESCRIPTION
* Fixes #829

We are not deleting the keys from the repository yet because we need to know they key in order to delete it from the server.

Whenever we add a key, we should run:

    ansible-playbook playbooks/provision.yml -l all-prod -t ssh_keys,app_user