### PR TITLE
Remove old apt source which caused failures

### DIFF
--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: remove old, failing config
+  lineinfile:
+    name: "/etc/apt/sources.list.d/pgdg.list"
+    line: "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main"
+    state: absent
+
 - name: configure datadog agent
   include_role:
     name: Datadog.datadog


### PR DESCRIPTION
Ubuntu 16 is not supported any more and `apt update` was failing.