### PR TITLE
Bump datadog from 3.1.0 to 4.16.0

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -18,7 +18,7 @@
   version: v2.0.14
 
 - src: Datadog.datadog
-  version: 3.1.0
+  version: 4.16.0
 
 - src: geerlingguy.postgresql
   version: 3.3.0


### PR DESCRIPTION
Many fixes including around APT management which has been a problem.