### PR TITLE
Update postgres role and config for db integration

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -21,7 +21,7 @@
   version: 4.16.0
 
 - src: geerlingguy.postgresql
-  version: 3.3.0
+  version: 3.4.0
 
 - src: libre_ops.multi_redis
   version: 1.0.1

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -137,6 +137,8 @@ postgresql_global_config_options:
     value: "300000"
   - option: include_dir
     value: "conf.d"
+  - option: log_directory
+    value: "log"
 
 debezium_version: "0.10.0.Final"
 

--- a/playbooks/db_integrations.yml
+++ b/playbooks/db_integrations.yml
@@ -10,12 +10,18 @@
   vars:
     postgresql_restarted_state: "restarted"
 
-  handlers:
-    - include: ../community/geerlingguy.postgresql/handlers/main.yml
-
   pre_tasks:
     - include_role:
         name: check_secrets
+
+  handlers:
+    - include: ../roles/shared_handlers/handlers/main.yml
+
+  roles:
+    - role: dbserver
+      become: yes
+      become_user: root
+      tags: dbserver
 
   tasks:
     - name: Apply integrations settings
@@ -27,8 +33,3 @@
       loop_control:
         loop_var: integration_item
       when: db_integrations is defined
-
-    - name: Reconfigure postgres
-      include_role:
-        name: geerlingguy.postgresql
-        tasks_from: configure


### PR DESCRIPTION
The db_integrations playbook was broken. I guess that the internal workings of the postgresql role changed and it didn't expect a subtask to be included on its own. I'm now including the whole role as in the provisioning playbook to make it work again and reduce maintenance. It will be a little bit slower though.