### PR TITLE
Unblock the installation of yarn on the CI (#1)

### DIFF
--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -15,3 +15,4 @@
   environment:
     NPM_CONFIG_PREFIX: "{{ npm_prefix }}"
     NODE_PATH: "{{ npm_prefix }}/lib/node_modules"
+    PATH: "/usr/bin:{{ ansible_env.PATH }}"


### PR DESCRIPTION
unblock the installation of yarn on the CI: an issue exist about this on the NPM module : ansible/ansible#29240 (comment) The workaround is to use enviroment to define the PATH in ansible's yaml