### PR TITLE
Increase Puma workers and threads for FR config

### DIFF
--- a/inventory/group_vars/fr.yml
+++ b/inventory/group_vars/fr.yml
@@ -23,3 +23,6 @@ users_sysadmin:
 maintenance_mode_message: >
   Une maintenance est en cours. Merci de patienter, la plateforme sera bientôt à nouveau disponible.
   Veuillez nous excuser pour la gêne occasionnée
+
+puma_workers: 4
+puma_threads: 4


### PR DESCRIPTION
This is related to the peformance issue we faced in France.

https://github.com/openfoodfoundation/openfoodnetwork/issues/9859

Increasing the workers and threads manually seems to give us better performance. Note that we have 8 workers on Nginx side. The idea was that Nginx requests were flooding Puma requests pool.

Oct 23, 5:10 pm – Oct 23, 11:19 pm
![Screenshot from 2022-11-02 12-02-43](https://user-images.githubusercontent.com/27745/199477389-cfafc696-1750-427f-9ea0-121a4949a248.png)

Oct 30, 5:10 pm – Oct 30, 11:19 pm
![Screenshot from 2022-11-02 12-04-14](https://user-images.githubusercontent.com/27745/199477466-059771b3-f0ba-4c19-a051-7f06d3a09cf1.png)

Even if it is not easy to compare as there is a bit less traffic on the second date, it seems to have a positive impact to have increase these workers and threads.