### PR TITLE
Upgrade to latest `yarn` version + upgrade all GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v2
         with:
@@ -27,7 +27,7 @@ jobs:
   playbook-tests:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Cache Ruby binary compiling
         id: cache-ruby
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.rbenv
           key: ${{ runner.os }}-ruby-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '2.7'
 
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '2.7'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '2.7'
+          python-version: '3.8.2'
 
       - name: Set up Ansible
         run: |
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '2.7'
+          python-version: '3.8.2'
 
       - name: Set up Ansible
         run: |

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -147,7 +147,7 @@ debezium_version: "0.10.0.Final"
 npm_prefix: "/usr/local/lib/npm"
 
 node_version: 14.x
-yarn_version: 1.22.4
+yarn_version: 1.22.19 # use the last stable version
 
 #----------------------------------------------------------------------
 # App variables

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ansible==2.9.20
 ansible-lint==4.2.0
 yamllint==1.21.0
+jinja2<3.1


### PR DESCRIPTION
Actually, do not close <!----> #838

* **Yarn** latest version
* **Node** no change
* **GH Actions** latest version each
* **Python** latest version
* Jinja2: lock to older version of Jinja2 (From memory, due to both Ansible 2.7 and our code)


Not sure how to test it actually. I guess this is a question for @mkllnk and @heroinedor ;)