### PR TITLE
Replace malloc with jemalloc

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -44,6 +44,7 @@
       - libxslt1-dev
       - libxrender1
       - webp
+      - libjemalloc2
   tags: packages
 
 - name: install base packages for old distros

--- a/roles/webserver/templates/puma.service.j2
+++ b/roles/webserver/templates/puma.service.j2
@@ -13,7 +13,7 @@ Environment=BUNDLE_GEMFILE={{ current_path }}/Gemfile
 # Helpful for debugging socket activation, etc.
 # Environment=PUMA_DEBUG=1
 
-ExecStart=/bin/bash -lc "bundle exec --keep-file-descriptors puma -C {{ shared_path }}/config/puma.rb"
+ExecStart=/bin/bash -lc "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 bundle exec --keep-file-descriptors puma -C {{ shared_path }}/config/puma.rb"
 ExecReload=/bin/bash -lc "bundle exec pumactl phased-restart -S {{ shared_path }}/pids/puma.state"
 
 SyslogIdentifier=puma


### PR DESCRIPTION
Hi 


The objective of this PR is to make the rails server use `jemalloc` instead of `malloc`. This modification may solve the memory leak issue as `jemalloc` frees the allocated memory space automatically when it's no longer in use.

In this PR, I installed the library on the sytem, then updated the command that runs the puma server on `roles/webserver/templates/puma.service.j2`

If this solution works, we can discuss compiling the ruby with jeamlloc as explained [here](https://scalingo.com/blog/improve-ruby-application-memory-jemalloc)
