### PR TITLE
Add websockets connection to `/cable`

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -388,6 +388,16 @@ nginx_sites:
         try_files /maintenance.html =503;
       }
 
+      location /cable {
+        {{ nginx_valid_methods }}
+        proxy_pass http://rails;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Ssl on;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+      }
+
       client_max_body_size 4G;
       keepalive_timeout {{ puma_timeout }};
       proxy_read_timeout {{ puma_timeout }};


### PR DESCRIPTION
Closes #851

#### How to test

Probably the best way is to provision a staging server (not the FR one), which is well configured + deploy https://github.com/openfoodfoundation/openfoodnetwork/pull/9804 on that server and check that on `/admin/orders` page you don't have any websocket errors