### PR TITLE
Use valid TLS certificate for db integrations

### DIFF
--- a/roles/db_integrations/tasks/main.yml
+++ b/roles/db_integrations/tasks/main.yml
@@ -75,16 +75,12 @@
 
 - name: "Call copy script on certificate renewal"
   become: yes
-  lineinfile:
-    dest: "/etc/letsencrypt/renewal/{{ certbot_cert_name | default(domain) }}.conf"
-    regex: "^renew_hook"
-    line: "renew_hook = /etc/letsencrypt/renewal-hooks/postgresql.sh"
-    state: present
-  # Non-idempotent alternative:
-  # command: >-
-  #   certbot renew --force-renewal --no-random-sleep-on-renew
-  #   --cert-name "{{ certbot_cert_name | default(domain) }}"
-  #   --deploy-hook "/etc/letsencrypt/renewal-hooks/postgresql.sh"
+  command: >-
+    certbot renew --force-renewal --no-random-sleep-on-renew
+    --cert-name "{{ certbot_cert_name | default(domain) }}"
+    --deploy-hook "/etc/letsencrypt/renewal-hooks/postgresql.sh"
+  args:
+    creates: "/etc/postgresql/fullchain.pem"
   when: inventory_hostname not in groups['local']
 
 - name: Use valid TLS certificate

--- a/roles/db_integrations/tasks/main.yml
+++ b/roles/db_integrations/tasks/main.yml
@@ -63,3 +63,45 @@
     state: absent
   when: db_integration.state == 'absent' and db_user_exists.stdout == '1'
   register: integration_config
+
+- name: Install script to copy valid TLS certificates for postgresql
+  become: yes
+  template:
+    src: "cert-renewal-hook.sh.j2"
+    dest: "/etc/letsencrypt/renewal-hooks/postgresql.sh"
+    owner: "root"
+    mode: "0755"
+  when: inventory_hostname not in groups['local']
+
+- name: "Call copy script on certificate renewal"
+  become: yes
+  lineinfile:
+    dest: "/etc/letsencrypt/renewal/{{ certbot_cert_name | default(domain) }}.conf"
+    regex: "^renew_hook"
+    line: "renew_hook = /etc/letsencrypt/renewal-hooks/postgresql.sh"
+    state: present
+  # Non-idempotent alternative:
+  # command: >-
+  #   certbot renew --force-renewal --no-random-sleep-on-renew
+  #   --cert-name "{{ certbot_cert_name | default(domain) }}"
+  #   --deploy-hook "/etc/letsencrypt/renewal-hooks/postgresql.sh"
+  when: inventory_hostname not in groups['local']
+
+- name: Use valid TLS certificate
+  become: yes
+  lineinfile:
+    dest: "/etc/postgresql/{{ postgresql_version }}/main/postgresql.conf"
+    regex: "^ssl_cert_file"
+    line: "ssl_cert_file = '/etc/postgresql/fullchain.pem'"
+    state: present
+  when: inventory_hostname not in groups['local']
+
+- name: Use valid TLS key
+  become: yes
+  lineinfile:
+    dest: "/etc/postgresql/{{ postgresql_version }}/main/postgresql.conf"
+    regex: "^ssl_key_file"
+    line: "ssl_key_file = '/etc/postgresql/privkey.pem'"
+    state: present
+  notify: restart postgres
+  when: inventory_hostname not in groups['local']

--- a/roles/db_integrations/templates/cert-renewal-hook.sh.j2
+++ b/roles/db_integrations/templates/cert-renewal-hook.sh.j2
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Postgresql doesn't have access to Certbot certificates.
+# This renewal hook copies the certificate files to make them accessible.
+
+umask 0177
+
+SRC="/etc/letsencrypt/live/{{ certbot_cert_name | default(domain) }}"
+DST="/etc/postgresql"
+
+cp "$SRC/fullchain.pem" "$DST/"
+cp "$SRC/privkey.pem" "$DST/"
+
+chown postgres:postgres "$DST/"*.pem
+
+systemctl reload postgresql


### PR DESCRIPTION
When database integrations accessed our database over the internet, Postgresql was using a self-signed certificate which makes us vulnerable to man-in-the-middle attacks. But we can easily use our Letsencrypt certificate for more secure connections.

* Enabling #822 in a secure way.

Postgresql doesn't have access to the certificate files though and we have to tell certbot to copy the files for postgresql.

## Testing instructions

I used au-staging to test this and it is provisioned already. So use another staging server like uk-staging to run the db_integrations playbook:

```
ansible-playbook --vault-password-file ../.ansible-vault-password --limit uk-staging --extra-vars @../ofn-secrets/uk-staging/secrets.yml playbooks/db_integrations.yml
```

Make sure that the OFN app still works. Connect n8n to the database with the option to require SSL (like *AU staging* credential). The connection check should pass.
