### PR TITLE
Remove nakayoshi_fork gem from puma config

### DIFF
--- a/roles/webserver/templates/puma.rb.j2
+++ b/roles/webserver/templates/puma.rb.j2
@@ -20,7 +20,6 @@ if ["production", "staging"].include?(ENV["RAILS_ENV"])
   prune_bundler
   wait_for_less_busy_worker
   fork_worker
-  nakayoshi_fork
   preload_app! false
 
   # Ensure clean Redis connections when forking


### PR DESCRIPTION
This gem is 6 years old and makes puma 6 not start: remove it
Seems unnecessary when using ruby 2.7
https://github.com/ko1/nakayoshi_fork/issues/5

Unblocks:

* https://github.com/openfoodfoundation/openfoodnetwork/pull/10217