### PR TITLE
Reduce memory-hungry Puma workers, add threads

### DIFF
--- a/inventory/group_vars/fr.yml
+++ b/inventory/group_vars/fr.yml
@@ -24,5 +24,5 @@ maintenance_mode_message: >
   Une maintenance est en cours. Merci de patienter, la plateforme sera bientôt à nouveau disponible.
   Veuillez nous excuser pour la gêne occasionnée
 
-puma_workers: 4
-puma_threads: 4
+puma_workers: 2
+puma_threads: 8


### PR DESCRIPTION
Puma is multi-threaded and one process can handle many connections without duplicating memory-use. We may need to increase the database connection pool size.

* Helps with #10016.