### PR TITLE
Create stats extension on all servers

### DIFF
--- a/roles/datadog/tasks/pg_stats.yml
+++ b/roles/datadog/tasks/pg_stats.yml
@@ -1,11 +1,4 @@
 ---
-- name: create extensions
-  become: yes
-  become_user: postgres
-  postgresql_ext:
-    name: pg_stat_statements
-    db: "{{ db }}"
-
 - name: add postgres stats configuration
   template:
     src: stats.conf.j2

--- a/roles/dbserver/tasks/main.yml
+++ b/roles/dbserver/tasks/main.yml
@@ -35,6 +35,7 @@
 - import_tasks: fix_template_encoding.yml
   tags: template_encoding
 
+# As required in db/schema.rb (for Datadog)
 - name: create pg_stat_statements extension
   become: yes
   become_user: postgres

--- a/roles/dbserver/tasks/main.yml
+++ b/roles/dbserver/tasks/main.yml
@@ -34,3 +34,10 @@
 
 - import_tasks: fix_template_encoding.yml
   tags: template_encoding
+
+- name: create pg_stat_statements extension
+  become: yes
+  become_user: postgres
+  postgresql_ext:
+    name: pg_stat_statements
+    db: "{{ db }}"


### PR DESCRIPTION
It's only used for Datadog but the Rails application is tracking extensions in its schema.rb file. Rails tries to create the extension itself if it doesn't exist and the db user is not allowed to create exensions at the moment. This seemed to be the easiest way but we could also give the db user the CREATE privilege instead.

### Dev test

Provision fr-staging and then try to deploy OFN master. It should succeed now. The other two staging servers have the extension already.

- [x] au-staging
- [x] fr-staging
- [x] uk-staging

Follow up from:

- https://github.com/openfoodfoundation/openfoodnetwork/pull/10278