### PR TITLE
Allow Metabase to connect to managed databases

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -116,6 +116,7 @@ default_hba_entries:
   - {type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5}
   - {type: host, database: all, user: all, address: '::1/128', auth_method: md5}
 
+custom_hba_metabase: {type: hostssl, database: "{{ db }}", user: "metabase", address: "167.99.89.242/32", auth_method: md5}
 custom_hba_n8n: {type: hostssl, database: "{{ db }}", user: "n8n", address: "128.199.44.140/32", auth_method: md5}
 
 custom_hba_entries: []

--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -21,5 +21,6 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
   - { type: hostssl, database: "{{ db }}", user: metabase, address: '167.99.89.242/32', auth_method: md5 }

--- a/inventory/host_vars/coopcircuits.fr/config.yml
+++ b/inventory/host_vars/coopcircuits.fr/config.yml
@@ -22,6 +22,7 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 

--- a/inventory/host_vars/openfoodnetwork.be/config.yml
+++ b/inventory/host_vars/openfoodnetwork.be/config.yml
@@ -19,5 +19,6 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }

--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -17,6 +17,7 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 

--- a/inventory/host_vars/openfoodnetwork.de/config.yml
+++ b/inventory/host_vars/openfoodnetwork.de/config.yml
@@ -19,6 +19,7 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 

--- a/inventory/host_vars/openfoodnetwork.hu/config.yml
+++ b/inventory/host_vars/openfoodnetwork.hu/config.yml
@@ -22,6 +22,7 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 #

--- a/inventory/host_vars/openfoodnetwork.ie/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ie/config.yml
@@ -17,5 +17,6 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }

--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -20,6 +20,7 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -26,6 +26,7 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '167.99.89.242/32', auth_method: md5 } # for metabase (data.openfoodnetwork.org.au)

--- a/inventory/host_vars/openfoodnetwork.org.nz/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.nz/config.yml
@@ -25,6 +25,7 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 #

--- a/inventory/host_vars/openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.uk/config.yml
@@ -14,6 +14,7 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 

--- a/inventory/host_vars/staging.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/staging.coopcircuits.fr/config.yml
@@ -24,5 +24,6 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }

--- a/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
@@ -29,5 +29,6 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }

--- a/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
@@ -35,5 +35,6 @@ postgres_listen_addresses:
   - '*'
 
 custom_hba_entries:
+  - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
 #  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }


### PR DESCRIPTION
Preparation for:

* https://github.com/openfoodfoundation/openfoodnetwork/issues/9161

Our Metabase server has been working with replicated databases. But our replication setup breaks regularly and we lost the knowledge how it works.

To simplify the setup, we are going to connect Metabase directly to the live database (with a statement timeout).

This pull request allows connecting to postgresql. We will still need to add the user with a secret password managed in ofn-secrets.