### PR TITLE
Remove auto fetch of ofn secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,19 @@ $ bin/setup
 
 ## Secrets
 
-Some tasks require host-specific secrets. These can be provided with a parameter like so:
+Some tasks require host-specific secrets, and will show an error if they haven't been provided. These can change from time to time, so **always ensure you have the latest before provisioning**.
+
+Secrets can be provided with a parameter like so:
 
 ```sh
-ansible-playbook playbooks/provision.yml --limit=au-prod -e "@../path/to/au-prod/secrets.yml"
+ansible-playbook playbooks/provision.yml --limit=au-staging -e "@../ofn-secrets/au-staging/secrets.yml"
 ```
 
-If you have access to the `ofn-secrets` repository, you can automatically fetch them with the `fetch_secrets` role, activated by an environment variable:
+If you have access to the `ofn-secrets` repository, you can fetch them with the `fetch_secrets.yml` playbook. The secrets for each host will be loaded into the relevant directory in `inventory/host_vars/`.
 
 ```sh
-    echo "export FETCH_OFN_SECRETS=TRUE" >> ~/.bash_profile
+ansible-playbook playbooks/fetch_secrets.yml
 ```
-But warning, there is an open issue with this method: https://github.com/openfoodfoundation/ofn-install/issues/861
 
 ## Code quality
 

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -1,18 +1,5 @@
 ---
 
-- name: fetch secrets
-  hosts: ofn_servers
-  remote_user: "{{ user }}"
-
-  tasks:
-    - name: update local secrets files
-      include_role:
-        name: fetch_secrets
-        apply:
-          delegate_to: 127.0.0.1
-      when: ( fetch_ofn_secrets is defined or lookup('env','FETCH_OFN_SECRETS') == 'TRUE' ) and inventory_hostname not in groups['local']
-      run_once: true
-
 - name: provision
   hosts: ofn_servers
   strategy: free


### PR DESCRIPTION
* Fixes #861

This was faulty: it would copy the latest files, but not load the values into memory, until next time you run ansible. Therefore you're always one step behind, and could copy old config onto a server (this has happened).

I tried to fix it with ansible's `refresh_inventory` command, but frustratingly can't get it to work:
* closes https://github.com/openfoodfoundation/ofn-install/pull/867

So I suggest you have to manually execute `fetch_secrets.yml` before provisioning.

## Documentation
After merging I'll also update the wiki:

1. https://github.com/openfoodfoundation/ofn-install/wiki/Provisioning#using-ofn-secrets
2. https://github.com/openfoodfoundation/ofn-install/wiki/Tips-for-core-sysadmins#setup-1