### PR TITLE
Deployment post tasks: Force `split_checkout` feature to be toggle on

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -72,3 +72,8 @@
         - debug:
             msg: Deployment failed
           failed_when: True # Ensure Ansible returns a non-zero error code after rescue
+
+  post_tasks:
+    - name: "Set feature `split_checkout` to `true` to all instances"
+      shell: "cd {{ build_path }} && rails runner 'Flipper.enable :split_checkout'
+      when: inventory_hostname not in groups['local']


### PR DESCRIPTION
Main question is: 

This will run after each deployment: should it be the case? Shouldn't we check for any version? 

Closes: https://github.com/openfoodfoundation/openfoodnetwork/issues/10658
