### PR TITLE
Apply Postgres tuning to all servers

### DIFF
--- a/playbooks/postgres_tuning.yml
+++ b/playbooks/postgres_tuning.yml
@@ -3,30 +3,9 @@
   hosts: ofn_servers
   remote_user: "{{ user }}"
 
-  tasks:
-    - name: Add tuning configuration
-      copy:
-        content: |
-          shared_buffers = {{ ( ansible_memtotal_mb / 4 ) | int }}MB
-          effective_cache_size = {{ ( ( ansible_memtotal_mb / 4 ) * 3 ) | int }}MB
-          maintenance_work_mem = {{ ( ansible_memtotal_mb / 16 ) | int }}MB
-          wal_buffers = 16MB
-          work_mem = 64MB
-        dest: "{{ postgresql_config_path }}/conf.d/tuning.conf"
-      become: yes
-      become_user: postgres
-      notify: restart postgres
-      when: remove_postgres_tuning is undefined
-
-    - name: Optionally remove tuning configuration
-      file:
-        path: "{{ postgresql_config_path }}/conf.d/tuning.conf"
-        state: absent
-      when: remove_postgres_tuning is defined
-
   handlers:
-    - name: restart postgres
-      service:
-        name: postgresql
-        state: restarted
-      become: yes
+    - include: ../roles/shared_handlers/handlers/main.yml
+
+  roles:
+    - role: postgres_tuning
+      tags: postgres_tuning

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -64,6 +64,9 @@
       become_user: root
       tags: dbserver
 
+    - role: postgres_tuning
+      tags: postgres_tuning
+
     - role: libre_ops.multi_redis
       vars:
         multiredis_disable_default_instance: false

--- a/roles/postgres_tuning/tasks/main.yml
+++ b/roles/postgres_tuning/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Add postgres tuning configuration
+  copy:
+    content: |
+      shared_buffers = {{ ( ansible_memtotal_mb / 5 ) | int }}MB
+      effective_cache_size = {{ ( ansible_memtotal_mb / 2 ) | int }}MB
+      maintenance_work_mem = {{ ( ansible_memtotal_mb / 25 ) | int }}MB
+      wal_buffers = 16MB
+      work_mem = {{ ( ansible_memtotal_mb / 400 ) | int }}MB
+    dest: "{{ postgresql_config_path }}/conf.d/tuning.conf"
+  become: yes
+  become_user: postgres
+  notify: restart postgres
+  when: remove_postgres_tuning is undefined
+
+- name: Optionally remove tuning configuration
+  file:
+    path: "{{ postgresql_config_path }}/conf.d/tuning.conf"
+    state: absent
+  when: remove_postgres_tuning is defined


### PR DESCRIPTION
The default configuration for Postgres isn't really adequate for production environments when you install it from the standard package and don't configure it. We previously applied this configuration to larger instances on a case by case basis but it's been removed on some servers during server upgrades. I've scaled it down a little bit to be more conservative and added it to the provision playbook.

The technical part here is that if Postges is performing a lot of joins or complex queries and it can't hold what it needs in buffers, it actually stops and writes things to *disk* half way through a query and has to read them from disk again before it can return the results. Potentially even multiple times per query! This can massively increase the time it takes to complete a request.

I did some testing by running some reports as superadmin with a large date range using production data to simulate worst case scenarios and got a response time up to 8 seconds. After applying these configs locally the same request dropped down to around 1 second. Basically any querying where the complexity is on the high end of the scale (like with permissions) it should make a real difference.