### PR TITLE
Add libvips42 to base apt packages

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -36,6 +36,7 @@
 
       # OFN dependencies
       - imagemagick
+      - libvips42
       - libpq-dev
       - zlib1g-dev
       - libssl-dev


### PR DESCRIPTION
The libvips42 library enables use of ruby-vips for faster image processing.