### PR TITLE
Allow more time for cloning order cycles

### DIFF
--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -27,4 +27,4 @@ custom_hba_entries:
 enable_rails_apm: "false"
 
 # Allow more time to clone big order cycles.
-puma_timeout: "60"
+puma_timeout: "120"


### PR DESCRIPTION
This should be reset after the cloning has been made more efficient:

* https://github.com/openfoodfoundation/openfoodnetwork/pull/10832