### PR TITLE
Install ruby on deploy

### DIFF
--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -35,16 +35,14 @@
 
 # Ensure the correct Ruby version is activated for this build
 
-- name: register ruby version in new build
-  slurp:
-    src: "{{ build_path }}/.ruby-version"
-  register: deploy_ruby_version
-  become: yes
-
-- name: use ruby {{ deploy_ruby_version['content'] | b64decode | trim }} # noqa 301
-  shell: bash -lc "{{ rbenv_bin_path }}/rbenv global {{ deploy_ruby_version['content'] | b64decode | trim }} && rbenv rehash"
-  become: yes
-  become_user: "{{ app_user }}"
+- name: Install required Ruby version if needed
+  command: bash -lc "./script/rbenv-install.sh"
+  args:
+    chdir: "{{ build_path }}"
+  environment:
+    RUBY_CONFIGURE_OPTS: "--with-jemalloc"
+  register: rbenv_install
+  changed_when: rbenv_install.stdout.find("Installing ruby") != -1
 
 # Install bundler and gems
 

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -55,10 +55,22 @@
   register: bundler
   changed_when: bundler.stdout | length > 0
 
+- name: configure bundler
+  command: >
+    bash -lc "
+      bundle config set --local path '{{ gem_path }}'
+      bundle config set --local deployment 'true'
+      bundle config set --local without 'development:test'
+    "
+  args:
+    chdir: "{{ build_path }}"
+  become: true
+  become_user: "{{ app_user }}"
+
 - name: bundle install app dependencies
   # Note: the 'LANG=...' is a fix for broken rubygems utf8 handling.
   command: >
-    bash -lc "bundle install --path {{ gem_path }} --deployment --without development test"
+    bash -lc "bundle install"
   args:
     chdir: "{{ build_path }}"
   environment:

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -58,9 +58,9 @@
 - name: bundle install app dependencies
   # Note: the 'LANG=...' is a fix for broken rubygems utf8 handling.
   command: >
-    bash -lc "bundle install
-    --gemfile {{ build_path }}/Gemfile --path {{ gem_path }}
-    --deployment {{ '--without development test' if rails_env != 'development' else '' }}"
+    bash -lc "bundle install --path {{ gem_path }} --deployment --without development test"
+  args:
+    chdir: "{{ build_path }}"
   environment:
     LANG: "{{ language }}"
     LC_ALL: "{{ language }}"


### PR DESCRIPTION
Preparing for future Ruby upgrades.

* Unblocks https://github.com/openfoodfoundation/openfoodnetwork/pull/10888

There's more work to do. We currently install a specific Ruby version during provisioning which we don't need any more. But this pull request took me long enough to take a break here and continue another time.