### PR TITLE
Disabled datadog agents

### DIFF
--- a/roles/datadog/tasks/main.yml
+++ b/roles/datadog/tasks/main.yml
@@ -21,12 +21,13 @@
       tags:
         - "env:{{ rails_env }}"
         - "host-id:{{ host_id | default(ansible_limit) }}"
-      logs_enabled: true
+      logs_enabled: false
       apm_config:
-        enabled: "{{ enable_rails_apm | default('false') }}"
+        enabled: false
     datadog_config_ex:
       trace.config:
         env: "{{ rails_env }}"
+    datadog_enabled: false
   when: datadog_key is defined
 
 - name: set up postgres stats collection


### PR DESCRIPTION

* Prepares https://github.com/openfoodfoundation/ofn-install/issues/885

There's quite a bit to do to remove all our custom Datadog configurations but in the meantime it's very simple to just deactivate the Datadog agent services. fr-prod was the only host using it and I applied this change already. Hopefully Datadog will stop charging us now.