### PR TITLE
Add new relic env variable

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -88,3 +88,9 @@ smtp_password:
 #geocoder_api_key: pk.xxxx
 #geocoder_service: mapbox
 #geocoder_timeout: 7
+
+# New relic settings
+# see: https://one.eu.newrelic.com/admin-portal/, Administration > API keys to get the license key
+# new_relic_agent_enabled: true
+# new_relic_app_name: "Open Food Network"
+# new_relic_license_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/roles/app/templates/env.j2
+++ b/roles/app/templates/env.j2
@@ -93,4 +93,10 @@ OPENID_APP_ID="{{ openid_app_id }}"
 OPENID_APP_SECRET="{{ openid_app_secret }}"
 {% endif %}
 
+{% if new_relic_agent_enabled is defined %}
+NEW_RELIC_AGENT_ENABLED="{{ new_relic_agent_enabled }}"
+NEW_RELIC_APP_NAME="{{ new_relic_app_name }}"
+NEW_RELIC_LICENSE_KEY="{{ new_relic_license_key }}"
+{% endif %}
+
 {{ custom_env_vars | default('') }}


### PR DESCRIPTION
Related to #[10997](https://github.com/openfoodfoundation/openfoodnetwork/pull/10997)

Update secretes template and add environment variables needed to enable new relic : 
* NEW_RELIC_AGENT_ENABLED
* NEW_RELIC_APP_NAME
* NEW_RELIC_LICENSE_KEY

Once #[11256](https://github.com/openfoodfoundation/openfoodnetwork/pull/11256) is merged New relic can be turned on by setting the env variables.