### PR TITLE
Update Ubuntu version in LXD local testing setup

### DIFF
--- a/.lexi/container.yml
+++ b/.lexi/container.yml
@@ -1,5 +1,5 @@
 # Lexi container config
 container: ofn-install
-image: ubuntu:16.04
+image: ubuntu:18.04
 default_user: ofn-admin
 container_ip: 10.10.100.10


### PR DESCRIPTION
Bumps default Ubuntu version in the configs for testing Ansible branches locally with LXD.