### PR TITLE
Update name of multi_redis repository

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -17,7 +17,7 @@
 - src: geerlingguy.postgresql
   version: 3.4.0
 
-- src: libre_ops.multi_redis
+- src: libre-ops.multi_redis
   version: 1.0.1
 
 - src: arillso.logrotate

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -67,7 +67,7 @@
     - role: postgres_tuning
       tags: postgres_tuning
 
-    - role: libre_ops.multi_redis
+    - role: libre-ops.multi_redis
       vars:
         multiredis_disable_default_instance: false
       become: yes


### PR DESCRIPTION
Matt changed the underscore to a dash and downloading the role failed.

```
- downloading role 'multi_redis', owned by libre_ops
- downloading role from https://github.com/libre_ops/multi_redis/archive/1.0.1.tar.gz
Error: ]: failed to download the file: HTTP Error 404: Not Found
Warning: : - libre_ops.multi_redis was NOT installed successfully.
ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
```
https://github.com/openfoodfoundation/ofn-install/actions/runs/6374617784/job/17299450784