### PR TITLE
Set lower limit for journald logs

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -29,6 +29,9 @@
     - role: app_user # Create unprivileged user to run the app
       tags: app_user
 
+    - role: config # System config to help things run smoothly
+      tags: config
+
     - role: common # Install common apps and libraries, and setup shell.
       tags: common
 

--- a/roles/config/README.md
+++ b/roles/config/README.md
@@ -1,0 +1,1 @@
+General system config to keep things running smoothly.

--- a/roles/config/handlers/main.yml
+++ b/roles/config/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Restart journald
+  service: name=systemd-journald state=restarted
+  become: yes

--- a/roles/config/tasks/main.yml
+++ b/roles/config/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: "Set journal log size limit" # to avoid hard drive filling up!
+  lineinfile:
+    path: /etc/systemd/journald.conf
+    regexp: '^#\s*SystemMaxUse='
+    line: 'SystemMaxUse=100M'
+  notify: Restart journald
+  become: yes


### PR DESCRIPTION
To avoid hard drive filling up.

Dunno if it was a problem before, but it was easy to copy from another project.

Tested on au-staging:
```
~/projects/ofn-install $ ansible-playbook playbooks/provision.yml --tag=config -l au-staging
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details

PLAY [provision] *******************************************************************************************************
Thursday 05 October 2023  14:02:39 +1100 (0:00:00.122)       0:00:00.122 ******

TASK [Gathering Facts] *************************************************************************************************
ok: [staging.openfoodnetwork.org.au]
Thursday 05 October 2023  14:02:41 +1100 (0:00:01.888)       0:00:02.010 ******

TASK [config : Set journal log size limit] *****************************************************************************
changed: [staging.openfoodnetwork.org.au]
Thursday 05 October 2023  14:02:42 +1100 (0:00:00.913)       0:00:02.923 ******

RUNNING HANDLER [config : Restart journald] ****************************************************************************
changed: [staging.openfoodnetwork.org.au]

PLAY RECAP *************************************************************************************************************
staging.openfoodnetwork.org.au : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

Thursday 05 October 2023  14:02:43 +1100 (0:00:01.245)       0:00:04.169 ******
===============================================================================
Gathering Facts ------------------------------------------------------------------------------------------------- 1.89s
config : Restart journald --------------------------------------------------------------------------------------- 1.25s
config : Set journal log size limit ----------------------------------------------------------------------------- 0.91s
```