### PR TITLE
Retire JB's ssh access

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -240,7 +240,6 @@ core_devs:
   - maikel
   - matt
   - filipe
-  - jb
   - david
   - gaetan
 
@@ -248,6 +247,7 @@ retired_core_devs:
   - george
   - pau
   - stveep
+  - jb
 
 #----------------------------------------------------------------------
 # nginx config


### PR DESCRIPTION
JB left the organisation and I removed his SSH key from all servers already:

```
ansible-playbook playbooks/remove_ssh_keys.yml --limit all_prod,all_staging -e "{'remove_users_sysadmin':[jb]}"
```

This change makes sure that we don't add it again.