### PR TITLE
Restart after config changes

### DIFF
--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -33,6 +33,10 @@
     - { src: "env.j2", dest: "{{ config_path }}/.env.{{ rails_env }}" }
     - { src: "postgresql.yml.j2", dest: "{{ config_path }}/database.yml" }
   tags: app_templates
+  notify:
+    - restart puma
+    - restart postgres
+    - restart sidekiq
 
 - name: get l10n repo
   git:

--- a/roles/shared_handlers/handlers/main.yml
+++ b/roles/shared_handlers/handlers/main.yml
@@ -1,8 +1,8 @@
 # This role holds reusable handlers that can be included in multiple playbooks to keep things DRY
 
-- name: check service status
+- name: fetch services status # into the global variable ansible_facts.services
   service_facts:
-  listen:
+  listen: # run if the following tasks have been notified:
     - restart sidekiq
 
 - name: restart puma

--- a/roles/shared_handlers/handlers/main.yml
+++ b/roles/shared_handlers/handlers/main.yml
@@ -13,3 +13,10 @@
     state: restarted
   become: yes
   become_user: root
+
+- name: restart sidekiq
+  service:
+    name: sidekiq
+    state: restarted
+  become: yes
+  become_user: root

--- a/roles/shared_handlers/handlers/main.yml
+++ b/roles/shared_handlers/handlers/main.yml
@@ -1,5 +1,10 @@
 # This role holds reusable handlers that can be included in multiple playbooks to keep things DRY
 
+- name: check service status
+  service_facts:
+  listen:
+    - restart sidekiq
+
 - name: restart puma
   service:
     name: puma
@@ -20,3 +25,4 @@
     state: restarted
   become: yes
   become_user: root
+  when: ansible_facts.services['sidekiq.service']['state'] == 'running'


### PR DESCRIPTION
Ensure relevant services are restarted, after updating Rails or Postgres environment variables. Normally they would be restarted when the full provision playbook is executed anyway, but my vision is to be able to perform individual actions quicker. 
My vision: to update app config in a minute with`--tags=app`, instead of waiting ages for every single action to run. 

Probably this could have been separated into two separate tasks (one for Rails and one for Postgres). But it didn't seem worth spending more time on. Especially because additional tasks make ansible even slower...

I'm not sure why it failed on CI.
Update: I thought it was time to act on this one, so found a way to avoid the sidekiq error. Hmm, perhaps it was never started on initial setup? Then we should probably fix that.. but is this ok for now?