### PR TITLE
Add in_prod to list of globally managed servers

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -227,6 +227,7 @@ europe
 america
 au_prod
 nz_prod
+in_prod
 
 #------------------------------------------------------------------------------
 # Staging Servers


### PR DESCRIPTION
To ensure it gets deployed each week.

I considered creating an 'asia' group, but there's no need to group when there's only one so far.
