### PR TITLE
Pass in configured domain to ActionCable - related to #12020

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -397,6 +397,7 @@ nginx_sites:
         proxy_set_header X-Forwarded-Ssl on;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
       }
 
       client_max_body_size 4G;


### PR DESCRIPTION
**What? why?**

- Related to https://github.com/openfoodfoundation/openfoodnetwork/issues/12020
- ActionCable is unable to modify the query string due to the difference in domains. In the `products_reflex.rb#current_url` the `request.original_url` gets set to `https://rails` instead of the configured domain because no `Host` header is sent
- Send relevant headers in the action cable location block

**What should we test**
- Currently no tests written yet
- Staging was manually tested by @mkllnk and worked https://github.com/openfoodfoundation/ofn-install/pull/920#discussion_r1520582714
- We should test prod to confirm fix addresses issue, hence [#12020](https://github.com/openfoodfoundation/openfoodnetwork/issues/12020) should remain open until that fact

**References**
https://stackoverflow.com/questions/67696655/what-do-i-need-to-do-to-hook-up-actioncable-on-nginx-and-puma

https://github.com/rails/rails/issues/29893

**Followup**
@dacook was able to reproduce issue in dev https://github.com/openfoodfoundation/openfoodnetwork/issues/12020#issuecomment-1958175366 however without the same error messages hence there needs to be a followup to investigate that behaviour
