### PR TITLE
Add configuration to allow N8N to connect to the database

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -117,6 +117,8 @@ default_hba_entries:
 
 custom_hba_metabase: {type: hostssl, database: "{{ db }}", user: "metabase", address: "167.99.89.242/32", auth_method: md5}
 custom_hba_n8n: {type: hostssl, database: "{{ db }}", user: "n8n", address: "128.199.44.140/32", auth_method: md5}
+custom_hba_new_n8n: {type: hostssl, database: "{{ db }}", user: "n8n", address: "128.65.199.88/32", auth_method: md5}
+custom_hba_new_n8n_IPv6: {type: hostssl, database: "{{ db }}", user: "n8n", address: "2001:1600:13:101::633/128", auth_method: md5}
 
 custom_hba_entries: []
 

--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -26,7 +26,8 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_n8n }}"
-#  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"
 
 #custom_env_vars: |
 #  OFN_FEATURE_CONNECT_AND_LEARN="true"

--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -22,4 +22,5 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-  - { type: hostssl, database: "{{ db }}", user: metabase, address: '167.99.89.242/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"

--- a/inventory/host_vars/coopcircuits.fr/config.yml
+++ b/inventory/host_vars/coopcircuits.fr/config.yml
@@ -26,6 +26,7 @@ custom_hba_entries:
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_new_n8n }}"
   - "{{ custom_hba_new_n8n_IPv6 }}"
+  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 attachment_path: "home/openfoodnetwork/apps/openfoodnetwork/current/public/spree/products/:id/:style/:basename.:extension"
 attachment_url: ofn-prod.s3.us-east-1.amazonaws.com

--- a/inventory/host_vars/coopcircuits.fr/config.yml
+++ b/inventory/host_vars/coopcircuits.fr/config.yml
@@ -24,7 +24,8 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"
 
 attachment_path: "home/openfoodnetwork/apps/openfoodnetwork/current/public/spree/products/:id/:style/:basename.:extension"
 attachment_url: ofn-prod.s3.us-east-1.amazonaws.com

--- a/inventory/host_vars/csicsoka.org/config.yml
+++ b/inventory/host_vars/csicsoka.org/config.yml
@@ -24,7 +24,8 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-#  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"
 #
 #custom_env_vars: |
 #  OFN_FEATURE_CONNECT_AND_LEARN="true"

--- a/inventory/host_vars/openfoodnetwork.be/config.yml
+++ b/inventory/host_vars/openfoodnetwork.be/config.yml
@@ -21,4 +21,5 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-#  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"

--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -19,6 +19,7 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"
 
 enable_rails_apm: "false"

--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -21,5 +21,6 @@ custom_hba_entries:
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_new_n8n }}"
   - "{{ custom_hba_new_n8n_IPv6 }}"
+  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 enable_rails_apm: "false"

--- a/inventory/host_vars/openfoodnetwork.de/config.yml
+++ b/inventory/host_vars/openfoodnetwork.de/config.yml
@@ -21,6 +21,7 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-#  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"
 
 puma_timeout: 120

--- a/inventory/host_vars/openfoodnetwork.ie/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ie/config.yml
@@ -19,4 +19,5 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-#  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"

--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -22,7 +22,8 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"
 
 enable_rails_apm: "false"
 

--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -24,6 +24,7 @@ custom_hba_entries:
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_new_n8n }}"
   - "{{ custom_hba_new_n8n_IPv6 }}"
+  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 enable_rails_apm: "false"
 

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -30,6 +30,8 @@ custom_hba_entries:
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_new_n8n }}"
   - "{{ custom_hba_new_n8n_IPv6 }}"
+  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - { type: hostssl, database: "{{ db }}", user: zapier, address: '167.99.89.242/32', auth_method: md5 } # for metabase (data.openfoodnetwork.org.au)
 
 # Images settings
 attachment_path: "public/images/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -28,8 +28,8 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '167.99.89.242/32', auth_method: md5 } # for metabase (data.openfoodnetwork.org.au)
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"
 
 # Images settings
 attachment_path: "public/images/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/openfoodnetwork.org.nz/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.nz/config.yml
@@ -27,8 +27,9 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-#  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
-#
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"
+
 #custom_env_vars: |
 #  OFN_FEATURE_CONNECT_AND_LEARN="true"
 

--- a/inventory/host_vars/openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.uk/config.yml
@@ -18,5 +18,6 @@ custom_hba_entries:
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_new_n8n }}"
   - "{{ custom_hba_new_n8n_IPv6 }}"
+  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 attachment_url: ofn-uk-production.s3.us-east-1.amazonaws.com

--- a/inventory/host_vars/openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.uk/config.yml
@@ -16,6 +16,7 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"
 
 attachment_url: ofn-uk-production.s3.us-east-1.amazonaws.com

--- a/inventory/host_vars/staging.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/staging.coopcircuits.fr/config.yml
@@ -24,4 +24,5 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-#  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"

--- a/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
@@ -34,3 +34,4 @@ custom_hba_entries:
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_new_n8n }}"
   - "{{ custom_hba_new_n8n_IPv6 }}"
+   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }

--- a/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
@@ -32,4 +32,5 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"

--- a/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
@@ -35,4 +35,5 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"
-#  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+  - "{{ custom_hba_new_n8n }}"
+  - "{{ custom_hba_new_n8n_IPv6 }}"


### PR DESCRIPTION
Fix #924

Update `ph_hba.conf` to allow the new N8N server to connect to postgres database

I added both IPv4 and IPv6 entry, I am not sure if it's strictly necessary but it doesn't hurt to cover everything
