### PR TITLE
Add RACK_TIMEOUT_TERM_ON_TIMEOUT for uk-prod

### DIFF
--- a/inventory/host_vars/openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.uk/config.yml
@@ -21,3 +21,5 @@ custom_hba_entries:
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 attachment_url: ofn-uk-production.s3.us-east-1.amazonaws.com
+
+rack_timeout_term_on_timeout: 3

--- a/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
@@ -37,3 +37,5 @@ custom_hba_entries:
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_new_n8n }}"
   - "{{ custom_hba_new_n8n_IPv6 }}"
+
+rack_timeout_term_on_timeout: 3

--- a/roles/app/templates/env.j2
+++ b/roles/app/templates/env.j2
@@ -4,6 +4,10 @@ SECRET_TOKEN="{{ secret_token }}"
 
 RACK_TIMEOUT_SERVICE_TIMEOUT="{{ puma_timeout }}"
 RACK_TIMEOUT_WAIT_TIMEOUT="{{ puma_timeout }}"
+{% if rack_timeout_term_on_timeout is defined %}
+RACK_TIMEOUT_TERM_ON_TIMEOUT="{{ rack_timeout_term_on_timeout }}"
+{% endif %}
+
 
 TIMEZONE="{{ timezone }}"
 DEFAULT_COUNTRY_CODE="{{ country_code }}"


### PR DESCRIPTION
UK prod is getting a rather high number of Rack Timeout errors : https://app.bugsnag.com/yaycode/openfoodnetwork-uk/errors/664378ec33e1080008ba685a?filters[error.status]=open&filters[event.since]=30d . Most likely due to long running queries.

As explained in the docs : https://github.com/zombocom/rack-timeout/blob/master/doc/settings.md#term-on-timeout it can cause the application to enter a in a corrupt state, and can cause database connection to not be released back in the db connection pool. This is most likely what has been happening on uk prod, we are seeing a high number of `ActiveRecord::ConnectionTimeoutError` see https://app.bugsnag.com/yaycode/openfoodnetwork-uk/errors/664b458a96db3b0007ce304a?filters[error.status]=open&filters[event.since]=30d

To mitigate the issue we can RACK_TIMEOUT_TERM_ON_TIMEOUT configuration which will reboot the puma worker after the number of timeout set by the config.  

It doesn't solve the underlying issue of long running request, but it should help.