### PR TITLE
Add RACK_TIMEOUT_TERM_ON_TIMEOUT for fr-prod

### DIFF
--- a/inventory/host_vars/coopcircuits.fr/config.yml
+++ b/inventory/host_vars/coopcircuits.fr/config.yml
@@ -30,3 +30,5 @@ custom_hba_entries:
 
 attachment_path: "home/openfoodnetwork/apps/openfoodnetwork/current/public/spree/products/:id/:style/:basename.:extension"
 attachment_url: ofn-prod.s3.us-east-1.amazonaws.com
+
+rack_timeout_term_on_timeout: 3


### PR DESCRIPTION
Part of https://github.com/openfoodfoundation/openfoodnetwork/issues/12761

same as `uk-prod` #932, adding RACK_TIMEOUT_TERM_ON_TIMEOUT to mitigate issue with the db connection pool.
