### PR TITLE
[Citi OFN Voucher] Add Activerecord encryption configuration and VINE api config

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -94,6 +94,3 @@ smtp_password:
 #active_record_encryption_primary_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 #active_record_encryption_deterministic_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 #active_record_encryption_key_derivation_salt: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-
-# VINE API settings
-#vine_api_url: "https://vine-url.com/api/v1"

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -94,3 +94,6 @@ smtp_password:
 #active_record_encryption_primary_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 #active_record_encryption_deterministic_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 #active_record_encryption_key_derivation_salt: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# VINE API settings
+#vine_api_url: "https://vine-url.com/api/v1"

--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -88,3 +88,9 @@ smtp_password:
 #new_relic_agent_enabled: true
 #new_relic_app_name: "Open Food Network"
 #new_relic_license_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# database encryption configuration, required for vine connected app
+# generate with bin/rails db:encryption:init
+#active_record_encryption_primary_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+#active_record_encryption_deterministic_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+#active_record_encryption_key_derivation_salt: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/inventory/host_vars/staging.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/staging.coopcircuits.fr/config.yml
@@ -26,3 +26,6 @@ custom_hba_entries:
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_new_n8n }}"
   - "{{ custom_hba_new_n8n_IPv6 }}"
+
+# VINE API settings
+vine_api_url: "https://vine-staging.openfoodnetwork.org.au/api/v1"

--- a/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
@@ -35,3 +35,6 @@ custom_hba_entries:
   - "{{ custom_hba_new_n8n }}"
   - "{{ custom_hba_new_n8n_IPv6 }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
+
+# VINE API settings
+vine_api_url: "https://vine-staging.openfoodnetwork.org.au/api/v1"

--- a/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
@@ -27,3 +27,6 @@ custom_hba_entries:
   - "{{ custom_hba_new_n8n_IPv6 }}"
 
 rack_timeout_term_on_timeout: 3
+
+# VINE API settings
+vine_api_url: "https://vine-staging.openfoodnetwork.org.au/api/v1"

--- a/roles/app/templates/env.j2
+++ b/roles/app/templates/env.j2
@@ -102,4 +102,8 @@ NEW_RELIC_APP_NAME="{{ new_relic_app_name }}"
 NEW_RELIC_LICENSE_KEY="{{ new_relic_license_key }}"
 {% endif %}
 
+ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY="{{ active_record_encryption_primary_key }}"
+ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY="{{ active_record_encryption_deterministic_key }}"
+ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="{{ active_record_encryption_key_derivation_salt }}"
+
 {{ custom_env_vars | default('') }}

--- a/roles/app/templates/env.j2
+++ b/roles/app/templates/env.j2
@@ -112,4 +112,8 @@ ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY="{{ active_record_encryption_determin
 ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="{{ active_record_encryption_key_derivation_salt }}"
 {% endif %}
 
+{% if vine_api_url is defined %}
+VINE_API_URL="{{ vine_api_url }}"
+{% endif %}
+
 {{ custom_env_vars | default('') }}

--- a/roles/app/templates/env.j2
+++ b/roles/app/templates/env.j2
@@ -102,8 +102,14 @@ NEW_RELIC_APP_NAME="{{ new_relic_app_name }}"
 NEW_RELIC_LICENSE_KEY="{{ new_relic_license_key }}"
 {% endif %}
 
+{% if active_record_encryption_primary_key is defined %}
 ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY="{{ active_record_encryption_primary_key }}"
+{% endif %}
+{% if active_record_encryption_deterministic_key is defined %}
 ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY="{{ active_record_encryption_deterministic_key }}"
+{% endif %}
+{% if active_record_encryption_key_derivation_salt is defined %}
 ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="{{ active_record_encryption_key_derivation_salt }}"
+{% endif %}
 
 {{ custom_env_vars | default('') }}


### PR DESCRIPTION
**⚠️ When working on this use the Clockify code: Citi Food Vouchers: #1A. https://github.com/openfoodfoundation/openfoodnetwork/issues/11922 Citi OFN Voucher - VINE Integration ⚠️**

Related to : https://github.com/openfoodfoundation/openfoodnetwork/pull/12886

Update env template and secret example to include activerecord encryption configuration and VINE_API_URL config.

