### PR TITLE
Bump Python from 3.8.2 to 3.9.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8.20'
+          python-version: '3.9.20'
 
       - name: Set up Ansible
         run: |
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8.20'
+          python-version: '3.9.20'
 
       - name: Set up Ansible
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8.2'
+          python-version: '3.8.20'
 
       - name: Set up Ansible
         run: |
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8.2'
+          python-version: '3.8.20'
 
       - name: Set up Ansible
         run: |

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,1 @@
-ofn-install
+ofn-install-3.9.20

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ It's recommended you set up your Python environment using [Pyenv](https://github
 * Install and configure [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)
 * Install the required Python version:
   ```
-  $ pyenv install 3.8.20
+  $ pyenv install 3.9.20
   ```
 * Create the virtualenv:
   ```
-  $ pyenv virtualenv 3.8.20 ofn-install
+  $ pyenv virtualenv 3.9.20 ofn-install-3.9.20
   ```
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ It's recommended you set up your Python environment using [Pyenv](https://github
 * Install and configure [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)
 * Install the required Python version:
   ```
-  $ pyenv install 3.8.2
+  $ pyenv install 3.8.20
   ```
 * Create the virtualenv:
   ```
-  $ pyenv virtualenv 3.8.2 ofn-install
+  $ pyenv virtualenv 3.8.20 ofn-install
   ```
 
 ### Dependencies


### PR DESCRIPTION
I needed to re-create my Python environment. So I decided to try the latest patch release of the current version and it seems to work. :tada: 

It just reached end of life last month... but updating is another project. Except, Github Actions doesn't support 3.8.20... okay, let's try the next version up.

#### :warning: Action required.

After updating to this version, you need to install the new version and create a new environment:

```
pyenv install 3.9.20
pyenv virtualenv 3.9.20 ofn-install-3.9.20

cd your/path/to/ofn-install
pip install -r requirements.txt
```