### PR TITLE
Add swapfile to fr_staging

### DIFF
--- a/inventory/host_vars/staging.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/staging.coopcircuits.fr/config.yml
@@ -21,6 +21,9 @@ attachment_url: ccs-ofn-staging.s3.eu-west-3.amazonaws.com
 postgres_listen_addresses:
   - '*'
 
+# The default is `false`, not installing a swapfile.
+swapfile_size: 1G
+
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
   - "{{ custom_hba_n8n }}"


### PR DESCRIPTION
- https://openfoodnetwork.slack.com/archives/CEBMTRCNS/p1726451615941249

Last month the memory usage hit 100% and interrupted testing. It  hasn't happened again, but I think it's worth having as a backup. Then the server will just slow down instead of crashing, which should still be enough of a canary to warn that something's going wrong. There's plenty of free disk space.

This hasn't been executed yet. 

## Action required after merge
Once approved I'll provision, using tag `swapfile`.