### PR TITLE
Use IP of new Ubuntu 20 server for IE

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -88,7 +88,7 @@ hu_prod
 ## Ireland
 
 [ie_prod]
-openfoodnetwork.ie ansible_host=167.172.44.121
+openfoodnetwork.ie ansible_host=64.227.64.162
 
 [ie:children]
 ie_prod


### PR DESCRIPTION
openfoodnetwork.ie has been upgraded to Ubuntu 20 now by following the instructions at https://github.com/openfoodfoundation/ofn-install/wiki/Migrating-a-Production-Server which were a great help. 

I noticed that the `pull_assets.yml` and `push_assets.yml` playbooks don't include the `storage` directory [here](https://github.com/openfoodfoundation/ofn-install/blob/master/roles/migrate_assets/defaults/main.yml). If an instance is configured to use `local` ActiveStorage this can be an issue, because I had to manually copy over the `storage` directory to the new server,  although most instances probably don't use `local`.

Let me know if you need any more details.