### PR TITLE
Fix remote deployment script

### DIFF
--- a/roles/remote_deployment/templates/deploy.j2
+++ b/roles/remote_deployment/templates/deploy.j2
@@ -33,4 +33,4 @@ cd "/home/{{ deployment_user }}/ofn-install"
 git pull
 
 # Deploy
-ansible-playbook playbooks/deploy.yml --limit {{ ansible_limit }} --connection local -e "git_repo=https://github.com/openfoodfoundation/openfoodnetwork.git git_version=$deploy"
+ansible-playbook playbooks/deploy.yml --limit {{ inventory_hostname }} --connection local -e "git_repo=https://github.com/openfoodfoundation/openfoodnetwork.git git_version=$deploy"


### PR DESCRIPTION
This issue was caused because I took the shortcut to provision all three servers at once:
```
ansible-playbook playbooks/setup_remote_deployment.yml -l all_staging
```

The playbook assumed that the `limit` param only refers to the current server, and pastes it into the deploy script. So I've updated it to specify only a reference to itself.