### PR TITLE
Add temporary domain

### DIFF
--- a/inventory/host_vars/openfoodnetwork.ie/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ie/config.yml
@@ -11,6 +11,7 @@ enable_nginx_logging: true
 certbot_domains:
   - openfoodnetwork.ie
   - www.openfoodnetwork.ie
+  - ubuntu-20.openfoodnetwork.ie # kept temporarily while some assets still load with this url (site logo)
 
 # Enable external database access for third party integrations
 postgres_listen_addresses:


### PR DESCRIPTION
- closes #958 

This allows the logo url to just work: https://ubuntu-20.openfoodnetwork.ie/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbmtiIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--e8d2b206705f494e912bb88b59a4b77f4c679022/ofn-ireland-logo.png

I've also added a redirect in `/etc/nginx/sites-available/`: 
```
# Temporary redirect after server migration (dcook 2024-11-07)
server {
   listen 80;
   listen 443;
   server_name  ubuntu-20.openfoodnetwork.ie;

   return 301 https://openfoodnetwork.ie$request_uri;
}
```

I have to admit I'm confused why this works, I haven't put it in sites-enabled yet. But the main thing is that it's working.