### PR TITLE
Block requests for .php

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -353,6 +353,12 @@ nginx_sites:
       brotli_types text/css text/javascript text/plain application/javascript application/x-javascript application/json;
 
       try_files $uri/index.html $uri @rails;
+
+      # Block scanning for scripts efficiently.
+      location ~ \.php(\?.*)?$ {
+        return 404;
+      }
+
       location @rails {
         {{ nginx_valid_methods }}
 


### PR DESCRIPTION
I was going to write an issue for this, so I could move on and avoid spending too much time on it. But I ended up just doing it..

Regex tested here so far, with a handful of examples I pulled out of Bugsnag (not an exhaustive analysis of logs by any means): https://regex101.com/r/lffH5m/1
We could probably block a lot more, but I reckon cutting out php will make a huge dent.
<img width="694" alt="Screenshot 2024-11-12 at 5 30 34 PM" src="https://github.com/user-attachments/assets/2ee3ac2e-018f-4b0a-9474-b42b7d736672">


Credit: this was copied and adapted from fairfood-install.

### Testing
This could be tested on a staging env:
* .php URLs are blocked with a basic 404 error. Not triggered in bugsnag
* able to browse the website normally. 
* Even if a shop has ".php" in the name, it should still work

## Post merge
If success, we can contribute this update back to fairfood-install.