### PR TITLE
Bump Ansible from 2.10 to 3.0

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,1 @@
-ofn-install-3.10.15
+ofn-install-3.10.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-ansible==2.10.7
+# Ansible community package
+# https://github.com/ansible-community/ansible-build-data
+ansible==3.0.0
+
 # This version doesn't work with the current Ansible version.
 # But upgrading seems to break the build.
 # TODO: upgrade ans fix ansible-lint


### PR DESCRIPTION
After version 2.10 the ansible-core package continues with 2.11 but the `ansible` community package jumps to version 3.0.0. This doesn't upgrade ansible-core which stays on 2.10.

Tests:

- [x] Setup virtual machine locally
- [x] Setup CI machine
- [x] Deploy to staging
- [x] Provision staging