### PR TITLE
Update node-build branch from master to main

### DIFF
--- a/roles/node/defaults/main.yaml
+++ b/roles/node/defaults/main.yaml
@@ -3,7 +3,7 @@ nodenv_plugins:
   # Allow installation of node versions
   - name: "node-build"
     repo: "https://github.com/nodenv/node-build.git"
-    version: master
+    version: main
   # Automatically install yarn after installing node
   - name: "nodenv-yarn-install"
     repo: "https://github.com/pine/nodenv-yarn-install"


### PR DESCRIPTION
The HEAD branch was renamed. Even after updating the name in Ansible, it still failed on not wanting to override a tag. The workaround is to delete the plugin remotely:

```
rm ~/.nodenv/plugins/node-build/ -rf
```

I don't think it's worth integrating into Ansible. It would be better to switch to a bash script installing node.