### PR TITLE
Remove db access for the old metabase server

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -112,9 +112,8 @@ default_hba_entries:
   - {type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5}
   - {type: host, database: all, user: all, address: '::1/128', auth_method: md5}
 
-custom_hba_metabase: {type: hostssl, database: "{{ db }}", user: "metabase", address: "167.99.89.242/32", auth_method: md5}
-custom_hba_new_metabase: {type: hostssl, database: "{{ db }}", user: "metabase", address: "89.47.50.240/32", auth_method: md5}
-custom_hba_new_metabase_IPv6: {type: hostssl, database: "{{ db }}", user: "metabase", address: "2001:1600:13:101::8d6/128", auth_method: md5}
+custom_hba_metabase: {type: hostssl, database: "{{ db }}", user: "metabase", address: "89.47.50.240/32", auth_method: md5}
+custom_hba_metabase_IPv6: {type: hostssl, database: "{{ db }}", user: "metabase", address: "2001:1600:13:101::8d6/128", auth_method: md5}
 custom_hba_n8n: {type: hostssl, database: "{{ db }}", user: "n8n", address: "128.65.199.88/32", auth_method: md5}
 custom_hba_n8n_IPv6: {type: hostssl, database: "{{ db }}", user: "n8n", address: "2001:1600:13:101::633/128", auth_method: md5}
 

--- a/inventory/host_vars/_example.com/config.yml
+++ b/inventory/host_vars/_example.com/config.yml
@@ -27,8 +27,8 @@ postgres_listen_addresses:
 custom_hba_entries:
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
 
 #custom_env_vars: |
 #  OFN_FEATURE_CONNECT_AND_LEARN="true"

--- a/inventory/host_vars/app.katuma.org/config.yml
+++ b/inventory/host_vars/app.katuma.org/config.yml
@@ -21,7 +21,6 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"

--- a/inventory/host_vars/coopcircuits.fr/config.yml
+++ b/inventory/host_vars/coopcircuits.fr/config.yml
@@ -23,8 +23,7 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }

--- a/inventory/host_vars/openfood.hu/config.yml
+++ b/inventory/host_vars/openfood.hu/config.yml
@@ -27,8 +27,7 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
 #

--- a/inventory/host_vars/openfoodnetwork.be/config.yml
+++ b/inventory/host_vars/openfoodnetwork.be/config.yml
@@ -20,7 +20,6 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"

--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -18,8 +18,7 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }

--- a/inventory/host_vars/openfoodnetwork.de/config.yml
+++ b/inventory/host_vars/openfoodnetwork.de/config.yml
@@ -20,8 +20,7 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
 

--- a/inventory/host_vars/openfoodnetwork.ie/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ie/config.yml
@@ -18,7 +18,6 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"

--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -21,8 +21,7 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -26,13 +26,10 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '167.99.89.242/32', auth_method: md5 } # for metabase (data.openfoodnetwork.org.uk)
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '89.47.50.240/32', auth_method: md5 } # for metabase (data.openfoodnetwork.org)
 
 # Images settings
 attachment_path: "public/images/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/openfoodnetwork.org.nz/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.nz/config.yml
@@ -26,8 +26,7 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
 

--- a/inventory/host_vars/openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.uk/config.yml
@@ -15,8 +15,7 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }

--- a/inventory/host_vars/staging.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/staging.coopcircuits.fr/config.yml
@@ -26,8 +26,7 @@ swapfile_size: 1G
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
 

--- a/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
@@ -31,8 +31,7 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
   - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }

--- a/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.uk/config.yml
@@ -18,8 +18,7 @@ postgres_listen_addresses:
 
 custom_hba_entries:
   - "{{ custom_hba_metabase }}"
-  - "{{ custom_hba_new_metabase }}"
-  - "{{ custom_hba_new_metabase_IPv6 }}"
+  - "{{ custom_hba_metabase_IPv6 }}"
   - "{{ custom_hba_n8n }}"
   - "{{ custom_hba_n8n_IPv6 }}"
 


### PR DESCRIPTION
Now that data.openfoodnetwork.org.uk is retired, remove database access. 

I also clean up `au_prod` to be in line with the current production configuration.