### PR TITLE
Skip installing ruby, the app does it

### DIFF
--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -2,9 +2,6 @@
 - src: geerlingguy.security
   version: 1.5.0
 
-- src: zzet.rbenv
-  version: 3.4.2
-
 - src: jdauphant.nginx
   version: v2.21.2
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -50,18 +50,6 @@ swapfile_size: false
 
 #----------------------------------------------------------------------
 # Rails variables
-ruby_version: 3.1.4
-
-rbenv_extra_depends:
-  - libjemalloc-dev
-
-ruby_compile_options: "--with-jemalloc"
-
-ruby_versions:
-  - version: 3.1.4
-    env:
-      RUBY_CONFIGURE_OPTS: "{{ ruby_compile_options }}"
-
 env:
   RAILS_ENV: "{{ rails_env }}"
   PATH: "{{ gem_home }}/bin:{{ ansible_env.PATH }}"
@@ -421,16 +409,6 @@ nginx_configs:
 
 # Set python interpeter to the symlink created by setup
 ansible_python_interpreter: '/usr/bin/python'
-
-# Fix for renamed branch in rbenv-install repo
-rbenv_plugins:
-  - { name: "rbenv-vars",         repo: "https://github.com/rbenv/rbenv-vars.git",         version: "master" }
-  - { name: "ruby-build",         repo: "https://github.com/rbenv/ruby-build.git",         version: "master" }
-  - { name: "rbenv-default-gems", repo: "https://github.com/rbenv/rbenv-default-gems.git", version: "master" }
-  - { name: "rbenv-installer",    repo: "https://github.com/rbenv/rbenv-installer.git",    version: "main" }
-  - { name: "rbenv-update",       repo: "https://github.com/rkh/rbenv-update.git",         version: "master" }
-  - { name: "rbenv-whatis",       repo: "https://github.com/rkh/rbenv-whatis.git",         version: "master" }
-  - { name: "rbenv-use",          repo: "https://github.com/rkh/rbenv-use.git",            version: "master" }
 
 template_notice: |
   # Managed via ofn-install, any changes will be overwritten.

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -41,17 +41,6 @@
     - role: language # Setup locale.
       tags: language
 
-    - role: zzet.rbenv # Install ruby. If missing run: ansible-galaxy install zzet.rbenv
-      rbenv:
-        env: user
-        version: v1.0.0
-        default_ruby: "{{ ruby_version }}"
-        rubies: "{{ ruby_versions }}"
-      rbenv_set_vars: false
-      rbenv_users:
-        - "{{ app_user }}"
-      tags: ruby
-
     - role: app # Build the app directory structure and support files.
       become: yes
       become_user: "{{ app_user }}"
@@ -111,14 +100,6 @@
       tags: newrelic
 
   tasks:
-    - name: Fix Ruby # no-changed-when
-      command:
-        cmd: bash -lc "rbenv uninstall -f {{ ruby_version }} && rbenv install {{ ruby_version }} && touch ~/.rbenv/versions/{{ ruby_version }}/.reinstalled"
-        creates: "~/.rbenv/versions/{{ ruby_version }}/.reinstalled"
-      become: yes
-      become_user: "{{ app_user }}"
-      when: ansible_distribution_major_version >= '20'
-
     - meta: flush_handlers # Ensure handlers run successfully before reporting success
 
     - name: notify slack

--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -45,9 +45,3 @@
     version={{ l10n_git_version }}
     force=yes
   tags: l10n
-
-- name: clear default rbenv vars
-  file:
-    dest: "{{ app_user_home_path }}/.rbenv/vars"
-    state: absent
-  become: yes

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -27,6 +27,7 @@
 
       # build ruby and gems
       - build-essential
+      - libjemalloc-dev
 
       # manage code
       - git-core


### PR DESCRIPTION
Now we don't have to manage the ruby version in two places. The bash script in the app is also faster than Ansible. Follow up from:

* https://github.com/openfoodfoundation/openfoodnetwork/pull/13034