### PR TITLE
Remove old python setup

### DIFF
--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -5,22 +5,6 @@
 # Use: `ansible-playbook playbooks/setup.yml -e "ansible_user=ubuntu" --limit <server_tag>` if
 # provisioning an EC2 instance for the first time (this only needs to be run once).
 
-# Ensure python is set up and accessible on the server before starting (ansible requires python2.7)
-- name: python check
-  hosts: ofn_servers
-  gather_facts: no
-  remote_user: root
-  tasks:
-    - name: Install python
-      become: yes
-      raw: |
-        test -e /usr/bin/python || (
-          test $(lsb_release -sr | cut -d . -f1) -lt 20 &&\
-          (apt-get update -qq && apt-get install -qq python2.7 && ln -s /usr/bin/python2.7 /usr/bin/python) ||\
-          (apt-get update -qq && apt-get install -qq python3 && ln -s /usr/bin/python3 /usr/bin/python)
-        )
-      tags: skip_ansible_lint
-
 # Add the default user and ssh keys as root
 - name: set up default_user
   hosts: ofn_servers


### PR DESCRIPTION
- Closes #765

This was only executed for Ubuntu older than Ubuntu 20 but all new servers do have Ubuntu 20. We also don't require old Python anymore.