### PR TITLE
Force fetch nodenv plugins

### DIFF
--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -14,6 +14,7 @@
     repo: "{{ item.repo }}"
     dest: "{{ nodenv_root }}/plugins/{{ item.name }}"
     version: "{{ item.version }}"
+    force: yes # because node-build keeps updating a tag ref
 
 - name: add nodenv to user path
   blockinfile:


### PR DESCRIPTION
- Fixes #968

because node-build keeps updating a tag ref, causing error:
```
Failed to download remote objects and refs:  From https://github.com/nodenv/node-build
   43a77880..41c93786  main       -> origin/main
   43a77880..41c93786  master     -> origin/master
 ! [rejected]          v5         -> v5  (would clobber existing tag)
 * [new tag]           v5.3.23    -> v5.3.23
```

Now, it should just work when provisioning next.