### PR TITLE
Re-introduce python installation

### DIFF
--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -5,6 +5,23 @@
 # Use: `ansible-playbook playbooks/setup.yml -e "ansible_user=ubuntu" --limit <server_tag>` if
 # provisioning an EC2 instance for the first time (this only needs to be run once).
 
+# Ensure python is set up and accessible on the server before starting.
+- name: python check
+  hosts: ofn_servers
+  gather_facts: no
+  remote_user: root
+  tasks:
+    - name: Install python
+      become: yes
+      raw: |
+        test -e /usr/bin/python || (
+          apt-get update -qq &&\
+          apt-get install -q --yes python3 &&\
+          ln -s /usr/bin/python3 /usr/bin/python
+        )
+      register: python_install
+      changed_when: python_install.stdout == ""
+
 # Add the default user and ssh keys as root
 - name: set up default_user
   hosts: ofn_servers


### PR DESCRIPTION
This reverts commit a872e875d4367adba0bb9dc627a10db303f1d67c.

I misread the conditional chain and thought that the original code was only installing python for old Ubuntu versions. But it was just choosing the right python version depending on the Ubuntu version. We can now assume Python 3 and simplify the check.