### PR TITLE
Enable default redis instance

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -66,6 +66,9 @@
       become_user: root
       tags: redis
 
+    - role: enable_redis
+      tags: enable_redis
+
     - role: sidekiq
       tags: sidekiq
 

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,7 +1,0 @@
----
-
-- name: restart redis
-  service:
-    name: redis-server
-    state: restarted
-  become: yes

--- a/roles/enable_redis/tasks/main.yml
+++ b/roles/enable_redis/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+# According to the docs Redis should be started automatically :
+#   https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/install-redis-on-linux/#install-on-ubuntudebian
+# But in reality the default instance is not always enabled so we do it manually
+- name: Enable default redis instance
+  service:
+    name: redis-server
+    state: started
+    enabled: true 
+  become: true 


### PR DESCRIPTION
While looking at setting monitoring for all redis instances, I noticed a some of our prod instances don't have the default redis instances. That means we can't update the ActionCable configuration to use said instance as proposed here https://github.com/openfoodfoundation/openfoodnetwork/pull/13072

According to the [documentation](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/install-redis-on-linux/) redis should be enable/start automatically but it appears to not always be the case.
This PR add a new role to make sure the default instance of redis is enable and running when provisioning a server.