### PR TITLE
Run tests on CI with LXC container 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,41 @@ jobs:
       - name: Ansible Lint
         run: bin/lint
 
+  playbook-tests-lxc:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10.15'
+
+      - name: Set up Ansible
+        run: |
+          pip install -r requirements.txt
+          bin/setup
+
+      - name: Cache Ruby binary compiling
+        id: cache-ruby
+        uses: actions/cache@v3
+        with:
+          path: ~/.rbenv
+          key: ${{ runner.os }}-ruby-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ruby-
+            ${{ runner.os }}-
+
+      - name: Set up LXD
+        run: |
+          sudo apt-get install --yes lxd
+          sudo lxd init --auto
+          sudo usermod -aG lxd "$USER"
+          ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+          sudo su -c "`pwd`/bin/setup-lxc" - "$USER"
+
+      - name: Test Playbooks
+        run: ansible-playbook tests/suite.yml --limit lxc
+
   playbook-tests:
     runs-on: ubuntu-20.04
     steps:

--- a/bin/setup-lxc
+++ b/bin/setup-lxc
@@ -18,21 +18,28 @@
 #
 #   https://github.com/libre-ops/lexi
 
+set -e
+
 lxc launch ubuntu:20.04 ofn-dev
-lxc exec ofn-dev -- sh -c 'cat >> .ssh/authorized_keys' < ~/.ssh/id_rsa.pub
 
-# Enable browsing the OFN app via https://localhost:4433
-lxc config device add ofn-dev myport4433 proxy listen=tcp:0.0.0.0:4433 connect=tcp:127.0.0.1:443
+# The launch can take some time.
+while ! lxc exec ofn-dev -- sh -c 'cat >> .ssh/authorized_keys' < ~/.ssh/id_rsa.pub; do
+  sleep 1
+done
 
-ip_address="$(lxc list | grep ofn-dev | cut -d' ' -f6)"
-echo "
-Host ofn.local
-  Hostname $ip_address
-  User root
-  UserKnownHostsFile /dev/null
-  StrictHostKeyChecking no
-  PasswordAuthentication no
-  LogLevel FATAL
-" >> "$HOME/.ssh/config"
+# Allow connection via SSH.
+# Your config could look like this:
+# ```
+# Host ofn-dev.lxc
+#   HostName 127.0.0.1
+#   Port 1122
+#   User root
+#   UserKnownHostsFile /dev/null
+#   StrictHostKeyChecking no
+#   PasswordAuthentication no
+#   LogLevel FATAL
+# ```
+lxc config device add ofn-dev myport1122 proxy listen=tcp:0.0.0.0:1122 connect=tcp:127.0.0.1:22
 
-ansible-playbook -l lxc site.yml
+# Enable browsing the OFN app via https://localhost:1443
+lxc config device add ofn-dev myport1443 proxy listen=tcp:0.0.0.0:1443 connect=tcp:127.0.0.1:443

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -5,7 +5,7 @@
 local_vagrant ansible_host=127.0.0.1 ansible_user=vagrant ansible_port=2222 ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 
 [lxc]
-ofn.local
+local_lxc ansible_host=127.0.0.1 ansible_user=root ansible_port=1122 ansible_ssh_common_args='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
 
 [lexi]
 local_lexi ansible_host=10.10.100.10 ansible_ssh_common_args='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR'

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -5,21 +5,21 @@
 # Use: `ansible-playbook playbooks/setup.yml -e "ansible_user=ubuntu" --limit <server_tag>` if
 # provisioning an EC2 instance for the first time (this only needs to be run once).
 
-# Ensure python is set up and accessible on the server before starting.
-- name: python check
+# Make the machine ready for basic setup.
+- name: Ensure machine is ready as Ansible host
   hosts: ofn_servers
   gather_facts: no
   remote_user: root
   tasks:
-    - name: Install python
+    - name: apt update
       become: yes
-      raw: |
-        test -e /usr/bin/python3 || (
-          apt-get update -qq &&\
-          apt-get install -q --yes python3
-        )
+      raw: apt-get update -qq
+      changed_when: true
+    - name: Install python if missing
+      become: yes
+      raw: test -e /usr/bin/python3 || apt-get install -q --yes python3
       register: python_install
-      changed_when: python_install.stdout == ""
+      changed_when: python_install.stdout != ""
 
 # Add the default user and ssh keys as root
 - name: set up default_user

--- a/roles/config/tasks/main.yml
+++ b/roles/config/tasks/main.yml
@@ -3,6 +3,7 @@
   hostname:
     name: "{{ host_id }}"
   become: yes
+  when: inventory_hostname not in groups['lxc']
 
 - name: "Set journal log size limit" # to avoid hard drive filling up!
   lineinfile:


### PR DESCRIPTION
We were running provisioning and deploy through a local connection on the Github runner itself. But when we upgrade to Ubuntu 22 and higher, that fails because of the permissions within the Github Actions container. So I decided to use a lightweight container which I've been using in development as well.

Now we are independent of the Github images and we could even run the tests against multiple Ubuntu versions in parallel.

The LXC setup took a little bit longer but not much:

* Old local setup: 17m
* LXC setup: 19m