### PR TITLE
Add support for Ubuntu 22 and Ubuntu 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,41 @@ jobs:
       - name: Ansible Lint
         run: bin/lint
 
+  playbook-tests-lxc:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10.15'
+
+      - name: Set up Ansible
+        run: |
+          pip install -r requirements.txt
+          bin/setup
+
+      - name: Cache Ruby binary compiling
+        id: cache-ruby
+        uses: actions/cache@v3
+        with:
+          path: ~/.rbenv
+          key: ${{ runner.os }}-ruby-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ruby-
+            ${{ runner.os }}-
+
+      - name: Set up LXD
+        run: |
+          sudo apt-get install --yes lxd
+          sudo lxd init --auto
+          sudo usermod -aG lxd "$USER"
+          ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+          sudo su -c "`pwd`/bin/setup-lxc" - "$USER"
+
+      - name: Test Playbooks
+        run: ansible-playbook tests/suite.yml --limit lxc
+
   playbook-tests:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,13 @@ jobs:
     # When we need to update from Ubuntu 20 then we can use incus which is
     # now the better fork of lxd.
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - "ubuntu:20.04"
+          - "ubuntu:22.04"
+          - "ubuntu:24.04"
     steps:
       - uses: actions/checkout@v3
 
@@ -57,7 +64,7 @@ jobs:
           sudo lxd init --auto
           sudo usermod -aG lxd "$USER"
           ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
-          sudo su -c "`pwd`/bin/setup-lxc" - "$USER"
+          sudo su -c "LXC_IMAGE='${{ matrix.image }}' `pwd`/bin/setup-lxc" - "$USER"
 
       - name: Test Playbooks
         run: ansible-playbook tests/suite.yml --limit lxc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ansible-lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
@@ -60,7 +60,7 @@ jobs:
         run: ansible-playbook tests/suite.yml --limit lxc
 
   playbook-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ansible-lint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -25,6 +25,9 @@ jobs:
         run: bin/lint
 
   playbook-tests-lxc:
+    # Ubuntu 22 and newer install lxd via snap which complicates things.
+    # When we need to update from Ubuntu 20 then we can use incus which is
+    # now the better fork of lxd.
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -58,33 +61,3 @@ jobs:
 
       - name: Test Playbooks
         run: ansible-playbook tests/suite.yml --limit lxc
-
-  playbook-tests:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10.16'
-
-      - name: Set up Ansible
-        run: |
-          pip install -r requirements.txt
-          bin/setup
-
-      - name: Cache Ruby binary compiling
-        id: cache-ruby
-        uses: actions/cache@v3
-        with:
-          path: ~/.rbenv
-          key: ${{ runner.os }}-ruby-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-ruby-
-            ${{ runner.os }}-
-
-      - name: Uninstall conflicting packages
-        run: sudo apt remove nginx libgd3
-
-      - name: Test Playbooks
-        run: ansible-playbook tests/suite.yml --limit test --connection local

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   ansible-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10.15'
+          python-version: '3.10.16'
 
       - name: Set up Ansible
         run: |
@@ -60,13 +60,13 @@ jobs:
         run: ansible-playbook tests/suite.yml --limit lxc
 
   playbook-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10.15'
+          python-version: '3.10.16'
 
       - name: Set up Ansible
         run: |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  config.vm.box = "generic/ubuntu2004"
+  config.vm.box = "generic/ubuntu2204"
 
   # VM network config.
   config.vm.network "forwarded_port", guest: 22, host: 2222

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  config.vm.box = "generic/ubuntu2204"
+  # Not available in the generic repository yet.
+  #config.vm.box = "generic/ubuntu2404"
+  config.vm.box = "alvistack/ubuntu-24.04"
 
   # VM network config.
   config.vm.network "forwarded_port", guest: 22, host: 2222

--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -13,7 +13,7 @@
   version: v2.0.14
 
 - src: geerlingguy.postgresql
-  version: 3.5.0
+  version: 3.5.2
 
 - src: libre_ops.multi_redis
   version: 1.0.1

--- a/bin/requirements.yml
+++ b/bin/requirements.yml
@@ -2,6 +2,8 @@
 - src: geerlingguy.security
   version: 1.5.0
 
+# TODO: replace with own role
+# Source repository has been archived without explanation.
 - src: jdauphant.nginx
   version: v2.21.2
 

--- a/bin/setup-lxc
+++ b/bin/setup-lxc
@@ -18,21 +18,28 @@
 #
 #   https://github.com/libre-ops/lexi
 
+set -e
+
 lxc launch ubuntu:20.04 ofn-dev
-lxc exec ofn-dev -- sh -c 'cat >> .ssh/authorized_keys' < ~/.ssh/id_rsa.pub
 
-# Enable browsing the OFN app via https://localhost:4433
-lxc config device add ofn-dev myport4433 proxy listen=tcp:0.0.0.0:4433 connect=tcp:127.0.0.1:443
+# The launch can take some time.
+while ! lxc exec ofn-dev -- sh -c 'cat >> .ssh/authorized_keys' < ~/.ssh/id_rsa.pub; do
+  sleep 1
+done
 
-ip_address="$(lxc list | grep ofn-dev | cut -d' ' -f6)"
-echo "
-Host ofn.local
-  Hostname $ip_address
-  User root
-  UserKnownHostsFile /dev/null
-  StrictHostKeyChecking no
-  PasswordAuthentication no
-  LogLevel FATAL
-" >> "$HOME/.ssh/config"
+# Allow connection via SSH.
+# Your config could look like this:
+# ```
+# Host ofn-dev.lxc
+#   HostName 127.0.0.1
+#   Port 1122
+#   User root
+#   UserKnownHostsFile /dev/null
+#   StrictHostKeyChecking no
+#   PasswordAuthentication no
+#   LogLevel FATAL
+# ```
+lxc config device add ofn-dev myport1122 proxy listen=tcp:0.0.0.0:1122 connect=tcp:127.0.0.1:22
 
-ansible-playbook -l lxc site.yml
+# Enable browsing the OFN app via https://localhost:1443
+lxc config device add ofn-dev myport1443 proxy listen=tcp:0.0.0.0:1443 connect=tcp:127.0.0.1:443

--- a/bin/setup-lxc
+++ b/bin/setup-lxc
@@ -20,7 +20,7 @@
 
 set -e
 
-lxc launch ubuntu:20.04 ofn-dev
+lxc launch ubuntu:22.04 ofn-dev
 
 # The launch can take some time.
 while ! lxc exec ofn-dev -- sh -c 'cat >> .ssh/authorized_keys' < ~/.ssh/id_rsa.pub; do

--- a/bin/setup-lxc
+++ b/bin/setup-lxc
@@ -20,7 +20,10 @@
 
 set -e
 
-lxc launch ubuntu:24.04 ofn-dev
+: ${LXC_IMAGE='ubuntu:24.04'}
+
+echo "Launching $LXC_IMAGE container:"
+lxc launch "$LXC_IMAGE" ofn-dev
 
 # The launch can take some time.
 while ! lxc exec ofn-dev -- sh -c 'cat >> .ssh/authorized_keys' < ~/.ssh/id_rsa.pub; do

--- a/bin/setup-lxc
+++ b/bin/setup-lxc
@@ -20,7 +20,7 @@
 
 set -e
 
-lxc launch ubuntu:22.04 ofn-dev
+lxc launch ubuntu:24.04 ofn-dev
 
 # The launch can take some time.
 while ! lxc exec ofn-dev -- sh -c 'cat >> .ssh/authorized_keys' < ~/.ssh/id_rsa.pub; do

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -82,7 +82,7 @@ postgres_encoding: en_US.utf8
 # Entries marked custom_* can be defined in /host_vars files, and will be appended
 # to the defaults if present. Make sure you use the "list" notation with the dashes!
 
-postgresql_version: "{% if ansible_distribution_major_version == '16' %}9.5{% elif ansible_distribution_major_version == '18' %}10{% elif ansible_distribution_major_version == '20' %}12{% else %}14{% endif %}"
+postgresql_version: "{% if ansible_distribution_major_version == '16' %}9.5{% elif ansible_distribution_major_version == '18' %}10{% elif ansible_distribution_major_version == '20' %}12{% elif ansible_distribution_major_version == '22' %}14{% else %}16{% endif %}"
 postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
 postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
 postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -82,7 +82,7 @@ postgres_encoding: en_US.utf8
 # Entries marked custom_* can be defined in /host_vars files, and will be appended
 # to the defaults if present. Make sure you use the "list" notation with the dashes!
 
-postgresql_version: "{% if ansible_distribution_major_version == '16' %}9.5{% elif ansible_distribution_major_version == '18' %}10{% else %}12{% endif %}"
+postgresql_version: "{% if ansible_distribution_major_version == '16' %}9.5{% elif ansible_distribution_major_version == '18' %}10{% elif ansible_distribution_major_version == '20' %}12{% else %}14{% endif %}"
 postgresql_data_dir: "/var/lib/postgresql/{{ postgresql_version }}/main"
 postgresql_bin_path: "/usr/lib/postgresql/{{ postgresql_version }}/bin"
 postgresql_config_path: "/etc/postgresql/{{ postgresql_version }}/main"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -127,8 +127,6 @@ postgresql_global_config_options:
   - option: log_directory
     value: "log"
 
-debezium_version: "0.10.0.Final"
-
 #----------------------------------------------------------------------
 # App variables
 app: openfoodnetwork

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -242,9 +242,12 @@ ssl_certificate_key:  "/etc/letsencrypt/live/{{ certbot_cert_name | default(doma
 
 nginx_official_repo: True
 
-nginx_extra_root_params:
-  - load_module modules/ngx_http_brotli_filter_module.so
-  - load_module modules/ngx_http_brotli_static_module.so
+possible_nginx_extra_root_params:
+  - "{{ (ansible_distribution_major_version <= '20') | ternary('load_module modules/ngx_http_brotli_filter_module.so','') }}"
+  - "{{ (ansible_distribution_major_version <= '20') | ternary('load_module modules/ngx_http_brotli_static_module.so','') }}"
+
+# Filter out empty items:
+nginx_extra_root_params: "{{ possible_nginx_extra_root_params | select }}"
 
 nginx_http_params:
   - sendfile "on"
@@ -335,8 +338,10 @@ nginx_sites:
       gzip_types text/css text/javascript text/plain application/javascript application/x-javascript application/json;
       gzip_disable "msie6";
 
+      {% if ansible_distribution_major_version <= "20" %}
       brotli on;
       brotli_types text/css text/javascript text/plain application/javascript application/x-javascript application/json;
+      {% endif %}
 
       try_files $uri/index.html $uri @rails;
 
@@ -366,7 +371,9 @@ nginx_sites:
       location ~ ^/(assets)/ {
         {{ nginx_valid_methods }}
         gzip_static on;
+        {% if ansible_distribution_major_version <= "20" %}
         brotli_static on;
+        {% endif %}
         expires max;
         add_header Cache-Control public;
       }

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -5,7 +5,7 @@
 local_vagrant ansible_host=127.0.0.1 ansible_user=vagrant ansible_port=2222 ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 
 [lxc]
-ofn.local
+local_lxc ansible_host=127.0.0.1 ansible_user=root ansible_port=1122 ansible_ssh_common_args='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
 
 [lexi]
 local_lexi ansible_host=10.10.100.10 ansible_ssh_common_args='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR'

--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -81,6 +81,7 @@
       tags: certbot
 
     - role: brotli_nginx
+      when: ansible_distribution_major_version <= '20'
       tags: brotli
 
     - role: jdauphant.nginx

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -5,21 +5,21 @@
 # Use: `ansible-playbook playbooks/setup.yml -e "ansible_user=ubuntu" --limit <server_tag>` if
 # provisioning an EC2 instance for the first time (this only needs to be run once).
 
-# Ensure python is set up and accessible on the server before starting.
-- name: python check
+# Make the machine ready for basic setup.
+- name: Ensure machine is ready as Ansible host
   hosts: ofn_servers
   gather_facts: no
   remote_user: root
   tasks:
-    - name: Install python
+    - name: apt update
       become: yes
-      raw: |
-        test -e /usr/bin/python3 || (
-          apt-get update -qq &&\
-          apt-get install -q --yes python3
-        )
+      raw: apt-get update -qq
+      changed_when: true
+    - name: Install python if missing
+      become: yes
+      raw: test -e /usr/bin/python3 || apt-get install -q --yes python3
       register: python_install
-      changed_when: python_install.stdout == ""
+      changed_when: python_install.stdout != ""
 
 # Add the default user and ssh keys as root
 - name: set up default_user

--- a/roles/app_user/tasks/main.yml
+++ b/roles/app_user/tasks/main.yml
@@ -9,6 +9,12 @@
     shell: /bin/bash
   become: yes
 
+- name: Open home directory for reading by nginx
+  file:
+    path: "{{ app_user_home_path }}"
+    mode: "o+x" # Add execute to directory for other users.
+  become: yes
+
 - name: add ssh key
   authorized_key:
     user: "{{ app_user }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -14,7 +14,7 @@
   vars:
     packages:
       # Ansible support
-      - python-pycurl
+      - python3-pycurl
       - python3-psycopg2
 
       # unknown why or if needed

--- a/roles/config/tasks/main.yml
+++ b/roles/config/tasks/main.yml
@@ -3,6 +3,7 @@
   hostname:
     name: "{{ host_id }}"
   become: yes
+  when: inventory_hostname not in groups['lxc']
 
 - name: "Set journal log size limit" # to avoid hard drive filling up!
   lineinfile:


### PR DESCRIPTION
Relates to:

* #157

Includes and depends on:

* #989

The brotli compilation failed on newer Ubuntu versions. I chose the easy path for now to deactivate brotli for newer Ubuntu since it's only relevant for a few servers and only when we actually replace servers again.

From Ubuntu 24 onwards, brotli can be installed via apt. That may require replacing the used nginx role which isn't maintained any more anyway. That's a different task though.