### PR TITLE
Update path for certbot renewal hooks

### DIFF
--- a/roles/db_integrations/tasks/main.yml
+++ b/roles/db_integrations/tasks/main.yml
@@ -68,7 +68,7 @@
   become: yes
   template:
     src: "cert-renewal-hook.sh.j2"
-    dest: "/etc/letsencrypt/renewal-hooks/postgresql.sh"
+    dest: "/etc/letsencrypt/renewal-hooks/post/postgresql.sh"
     owner: "root"
     mode: "0755"
   when: inventory_hostname not in groups['local']


### PR DESCRIPTION
## Background

Our n8n server connects to Postgresql databases directly. The connection is encrypted and needs valid certificates. We re-use our Letsencrypt certificates that we get for nginx anyway and copy them for Postgresql.

Now, David T reported that the global dashboard hasn't been updated since December 2024. Testing one of the workflows, n8n reported that the certificated for au_prod was expired. The renewal hook had not been run. Newer versions of certbot have more specific paths for renewal hooks and our hook was still in the old path. I updated that now.

I didn't bother removing the old file. It would be temporary code and the file is not doing any harm. In fact, if one of the servers still uses an old version of certbot, deleting the old file may break database integrations.

I tested this on au-prod:

```
certbot renew --force-renewal
...
Congratulations, all renewals succeeded. The following certs have been renewed:
  /etc/letsencrypt/live/api.regenerative.org.au/fullchain.pem (success)
  /etc/letsencrypt/live/openfoodnetwork.org.au/fullchain.pem (success)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Running post-hook command: /etc/letsencrypt/renewal-hooks/post/postgresql.sh
```

And indeed, the cert files for postgres are renewed as well.