### PR TITLE
Remove superfluous hook reference

### DIFF
--- a/roles/db_integrations/tasks/main.yml
+++ b/roles/db_integrations/tasks/main.yml
@@ -78,7 +78,6 @@
   command: >-
     certbot renew --force-renewal --no-random-sleep-on-renew
     --cert-name "{{ certbot_cert_name | default(domain) }}"
-    --deploy-hook "/etc/letsencrypt/renewal-hooks/postgresql.sh"
   args:
     creates: "/etc/postgresql/fullchain.pem"
   when: inventory_hostname not in groups['local']


### PR DESCRIPTION
Now that the hook is in the right place, it gets called automatically.

Follow up from:

* #995

I noticed that I hadn't updated the path in this line but it can actually be removed. I'm already provisioning this version:

* https://github.com/openfoodfoundation/ofn-install/pull/995#issuecomment-2749723209