### PR TITLE
Run CI on ubuntu-latest and set up containers with Incus

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,18 +24,26 @@ jobs:
       - name: Ansible Lint
         run: bin/lint
 
-  playbook-tests-lxc:
-    # Ubuntu 22 and newer install lxd via snap which complicates things.
-    # When we need to update from Ubuntu 20 then we can use incus which is
-    # now the better fork of lxd.
-    runs-on: ubuntu-20.04
+  playbook-tests:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         image:
-          - "ubuntu:20.04"
-          - "ubuntu:22.04"
-          - "ubuntu:24.04"
+          # Most servers use Ubuntu 20. ~ 2025-06
+          #
+          #   ansible all_prod -u openfoodnetwork -a "lsb_release -d"
+          #   - Ubuntu 18:  2 servers
+          #   - Ubuntu 20: 10 servers
+          - "images:ubuntu/20.04"
+
+          # A dependency tries to install firefox and it fails.
+          # But we don't have any servers on this version anyway.
+          # We can skip it.
+          # - "images:ubuntu/22.04"
+
+          # Ready for the latest version. Finland uses this already.
+          - "images:ubuntu/24.04"
     steps:
       - uses: actions/checkout@v3
 
@@ -58,13 +66,16 @@ jobs:
             ${{ runner.os }}-ruby-
             ${{ runner.os }}-
 
-      - name: Set up LXD
+      - name: Reset the firewall for container network access
+        run: sudo nft flush ruleset
+
+      - name: Set up Incus
         run: |
-          sudo apt-get install --yes lxd
-          sudo lxd init --auto
-          sudo usermod -aG lxd "$USER"
+          sudo apt-get install --yes incus
+          sudo incus admin init --auto
+          sudo usermod -aG incus-admin "$USER"
           ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
-          sudo su -c "LXC_IMAGE='${{ matrix.image }}' `pwd`/bin/setup-lxc" - "$USER"
+          sudo su -c "LXC_IMAGE='${{ matrix.image }}' `pwd`/bin/setup-incus" - "$USER"
 
       - name: Test Playbooks
         run: ansible-playbook tests/suite.yml --limit lxc

--- a/bin/setup-incus
+++ b/bin/setup-incus
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Set up Linux Containers with Incus
+#
+# If you don't run Linux, you better look at Vagrant to set up virtual machines.
+#
+# But if you run Linux anyway then you can use containers to run virtual
+# machines on the same kernel instead of creating a full virtual machine.
+#
+# Installation in Debian:
+#
+#   sudo apt install incus
+#   sudo incus init
+#   sudo usermod -aG incus "$USER"
+#   # Restart your user's session to gain the new group privilege.
+
+set -e
+
+: ${LXC_IMAGE='images:ubuntu/24.04'}
+
+echo "Launching $LXC_IMAGE container:"
+incus launch "$LXC_IMAGE" ofn-dev
+incus exec ofn-dev -- apt-get update
+incus exec ofn-dev -- apt purge openssh-client --yes
+incus exec ofn-dev -- apt install openssh-server --yes
+incus exec ofn-dev -- mkdir -m 700 -p /root/.ssh
+incus file push --uid 0 --gid 0 ~/.ssh/id_rsa.pub ofn-dev/root/.ssh/authorized_keys
+
+incus config device add ofn-dev myport1122 proxy listen=tcp:0.0.0.0:1122 connect=tcp:127.0.0.1:22
+
+# Enable browsing the OFN app via https://localhost:1443
+incus config device add ofn-dev myport1443 proxy listen=tcp:0.0.0.0:1443 connect=tcp:127.0.0.1:443


### PR DESCRIPTION
Current Ubuntu 20 is no longer supported and we need to run a newer version for our tests.
Incus works better for us than the new LXD maintained by Canonical.

* Fixes #1000