### PR TITLE
Install libyaml-dev to build psych gem for Rails 7.1

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -45,6 +45,7 @@
       - libxml2-dev
       - libxslt1-dev
       - libxrender1
+      - libyaml-dev
       - webp
   tags: packages
 


### PR DESCRIPTION
* Unblocks https://github.com/openfoodfoundation/openfoodnetwork/pull/13232

All servers have been updated already.