### PR TITLE
Add log rotate for redis-cache and redis-jobs

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -213,7 +213,7 @@ logrotate_applications:
         options:
           - weekly        # run weekly
           - rotate 12     # delete logs older than 12 weeks
-          - missingok     # ignore missing lofs
+          - missingok     # ignore missing logs
           - compress      # compress rotated  logs
           - notifempty    # don't rotate if empty
 


### PR DESCRIPTION
While looking at the NZ server I realised that log for the non default instance of redis were not rotated. 
This add log rotation with the same config as the one for the default instance of redis.

Deploy command : 
```
ansible-playbook playbooks/provision.yml --tag logrotate --limit all_prod
```
