### PR TITLE
Add s3_cors_policy_domain var on template and example

### DIFF
--- a/inventory/host_vars/_example.com/secrets.example.yml
+++ b/inventory/host_vars/_example.com/secrets.example.yml
@@ -40,6 +40,8 @@ smtp_password:
 #s3_backups_region:
 # Optional settings for S3-compatible alternative endpoint:
 #s3_endpoint:
+# Optional settings for specific CORS Policy domain
+#s3_cors_policy_domain:
 
 # Stripe Connect API keys, set these if you are using Stripe
 # Find these under 'API keys' and 'Connect' in your Stripe account dashboard -> Account Settings

--- a/roles/app/templates/env.j2
+++ b/roles/app/templates/env.j2
@@ -49,6 +49,9 @@ S3_BUCKET="{{ s3_images_bucket }}"
 {% if s3_endpoint is defined %}
 S3_ENDPOINT="{{ s3_endpoint }}"
 {% endif %}
+{% if s3_cors_policy_domain is defined %}
+S3_CORS_POLICY_DOMAIN="{{ s3_cors_policy_domain }}"
+{% endif %}
 
 S3_HEADERS="{{ s3_headers }}"
 S3_PROTOCOL="{{ s3_protocol }}"


### PR DESCRIPTION
I was forgetting this new variable on the [PR](https://github.com/openfoodfoundation/openfoodnetwork/pull/13803).