### PR TITLE
Fix: SSH keys of retired core_devs are not removed from servers

### DIFF
--- a/roles/app_user/tasks/main.yml
+++ b/roles/app_user/tasks/main.yml
@@ -39,6 +39,7 @@
     user: "{{ app_user }}"
     key: "{{ lookup('file', inventory_dir + '/../files/keys/' + item + '.pub') }}"
     state: absent
+  become: yes
   with_flattened: "{{ retired_core_devs }}"
 
 - name: Write OFN environment variables defaults


### PR DESCRIPTION
**Closes #1038**

## Problem

The `authorized_key` task responsible for removing SSH keys of `retired_core_devs` was not effectively removing keys from the app_user's `~/.ssh/authorized_keys`.

Although no explicit error was raised during execution, the task lacked sufficient privileges to modify another user's SSH directory, resulting in a silent no-op.

## Solution

Added `become: yes` to the SSH key removal task to ensure it runs with elevated privileges and can correctly modify the app_user's  `authorized_keys` file.

```yaml
become: yes
