### PR TITLE
Add S3_REGION management in env template

### DIFF
--- a/roles/app/templates/env.j2
+++ b/roles/app/templates/env.j2
@@ -43,6 +43,9 @@ S3_BUCKET="{{ s3_images_bucket }}"
 {% if s3_endpoint is defined %}
 S3_ENDPOINT="{{ s3_endpoint }}"
 {% endif %}
+{% if s3_region is defined %}
+S3_REGION="{{ s3_region }}"
+{% endif %}
 {% if s3_cors_policy_domain is defined %}
 S3_CORS_POLICY_DOMAIN="{{ s3_cors_policy_domain }}"
 {% endif %}


### PR DESCRIPTION
I am not sure why, but the `S3_REGION` env var was not handled by the `env` template. It was not an issue for existing configurations as there was a [fallback for regions in storage.yml configuration](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/config/storage.yml#L17). We should keep an eye on DB2Fog who was handling the region on [its own](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/config/initializers/db2fog.rb#L24), but it should be fine.
Weirdly, I missed it while working on new S3-compatible setup... I have added the `S3_REGION` var into the `env` files, but as I thought the env var was already handled, I didn't ask to handle it. So it was only affecting the servers who have got new provisioning. I guess it was the case for the `FR staging` instance.