### PR TITLE
Update IP for new FR_staging instance server

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -162,7 +162,7 @@ es_prod
 coopcircuits.fr ansible_host=51.38.38.32
 
 [fr_staging]
-staging.coopcircuits.fr ansible_host=51.178.24.33
+staging.coopcircuits.fr ansible_host=57.131.49.35
 
 [fr:children]
 fr_prod


### PR DESCRIPTION
The new VPS is up and running. The DNS update was also done.
```
dig +short staging.coopcircuits.fr
57.131.49.35
```