### PR TITLE
Update IP address for new BE_prod server

### DIFF
--- a/inventory/hosts
+++ b/inventory/hosts
@@ -181,7 +181,7 @@ de_prod
 # Belgium
 
 [be_prod]
-openfoodnetwork.be ansible_host=38.180.86.174
+openfoodnetwork.be ansible_host=193.70.87.126
 
 [be:children]
 be_prod


### PR DESCRIPTION
The new BE_prod server has been setup, provisioned and the app has been deployed. The DNS Registar has been updated, and the new IP has been propagated.

```
❯ dig +short openfoodnetwork.be
193.70.87.126
```