### PR TITLE
Remove old Zapier IP address

### DIFF
--- a/inventory/host_vars/coopcircuits.fr/config.yml
+++ b/inventory/host_vars/coopcircuits.fr/config.yml
@@ -28,7 +28,6 @@ custom_hba_entries:
   - "{{ custom_hba_n8n_IPv6 }}"
   - "{{ custom_hba_zapier_1 }}"
   - "{{ custom_hba_zapier_2 }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 attachment_path: "home/openfoodnetwork/apps/openfoodnetwork/current/public/spree/products/:id/:style/:basename.:extension"
 attachment_url: ofn-prod.s3.us-east-1.amazonaws.com

--- a/inventory/host_vars/openfoodnetwork.ca/config.yml
+++ b/inventory/host_vars/openfoodnetwork.ca/config.yml
@@ -23,6 +23,5 @@ custom_hba_entries:
   - "{{ custom_hba_n8n_IPv6 }}"
   - "{{ custom_hba_zapier_1 }}"
   - "{{ custom_hba_zapier_2 }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 enable_rails_apm: "false"

--- a/inventory/host_vars/openfoodnetwork.net/config.yml
+++ b/inventory/host_vars/openfoodnetwork.net/config.yml
@@ -26,7 +26,6 @@ custom_hba_entries:
   - "{{ custom_hba_n8n_IPv6 }}"
   - "{{ custom_hba_zapier_1 }}"
   - "{{ custom_hba_zapier_2 }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 enable_rails_apm: "false"
 

--- a/inventory/host_vars/openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.au/config.yml
@@ -31,7 +31,6 @@ custom_hba_entries:
   - "{{ custom_hba_n8n_IPv6 }}"
   - "{{ custom_hba_zapier_1 }}"
   - "{{ custom_hba_zapier_2 }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 # Images settings
 attachment_path: "public/images/spree/products/:id/:style/:basename.:extension"

--- a/inventory/host_vars/openfoodnetwork.org.uk/config.yml
+++ b/inventory/host_vars/openfoodnetwork.org.uk/config.yml
@@ -20,7 +20,6 @@ custom_hba_entries:
   - "{{ custom_hba_n8n_IPv6 }}"
   - "{{ custom_hba_zapier_1 }}"
   - "{{ custom_hba_zapier_2 }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 attachment_url: ofn-uk-production.s3.us-east-1.amazonaws.com
 

--- a/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
+++ b/inventory/host_vars/staging.openfoodnetwork.org.au/config.yml
@@ -36,7 +36,6 @@ custom_hba_entries:
   - "{{ custom_hba_n8n_IPv6 }}"
   - "{{ custom_hba_zapier_1 }}"
   - "{{ custom_hba_zapier_2 }}"
-  - { type: hostssl, database: "{{ db }}", user: zapier, address: '54.86.9.50/32', auth_method: md5 }
 
 # VINE API settings
 vine_api_url: "https://vine-staging.openfoodnetwork.org.au/api/v1"


### PR DESCRIPTION
- Closes https://github.com/openfoodfoundation/ofn-install/issues/1031

Zapier updated their IP addresses. The official entries are listed in this article:

- https://help.zapier.com/hc/en-us/articles/15406083674509-Use-a-static-IP-address-to-connect-to-Zapier

The old IP address should not be in use anymore. We should test that though.