### PR TITLE
Add ffmpeg4 ppa for chromium

### DIFF
--- a/roles/chromium/tasks/main.yml
+++ b/roles/chromium/tasks/main.yml
@@ -12,6 +12,12 @@
     state: present
   become: yes
 
+- name: Add ffmpeg4 PPA for newer libpipewire
+  apt_repository:
+    repo: ppa:savoury1/ffmpeg4
+    state: present
+  become: yes
+
 - name: Install chromium-browser
   apt:
     update_cache: yes


### PR DESCRIPTION
Most Ubuntu 20 servers didn't have access to the required version of libpipewire-0.3. This PPA adds that package and we can install Chromium.

This has already been applied to all managed servers.