### PR TITLE
Reduce puma worker count from 3 to 2 on fr_staging to save memory

### DIFF
--- a/inventory/host_vars/staging.coopcircuits.fr/config.yml
+++ b/inventory/host_vars/staging.coopcircuits.fr/config.yml
@@ -19,6 +19,9 @@ attachment_url: ccs-ofn-staging.s3.eu-west-3.amazonaws.com
 postgres_listen_addresses:
   - '*'
 
+# Reduce memory issues on the smaller staging server:
+puma_workers: 2
+
 # The default is `false`, not installing a swapfile.
 swapfile_size: 1G
 


### PR DESCRIPTION
Deployments sometimes fail on fr-staging. It's probably running out of memory and puma is the biggest memory consumer. Since staging has only half the memory of production, we should reduce the worker count here as well. Now fr_prod still has 3 workers and staging has 2 workers.

I applied this already.